### PR TITLE
fix: correct EN installer help filename and README resume

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -118,6 +118,7 @@ This installation method ensures correct handling of interactive prompts and col
     > sudo bash ./install_amneziawg_en.sh
     > ```
     > The English version is functionally identical; only user-facing messages and logs are in English.
+    > After reboots, resume with the same file: `sudo bash ./install_amneziawg_en.sh`
 
 5.  **Initial setup:** The script will interactively ask for:
     * **UDP port:** Port for client connections (1024-65535). Default: `39743`.

--- a/install_amneziawg_en.sh
+++ b/install_amneziawg_en.sh
@@ -104,7 +104,7 @@ die()       { log_error "CRITICAL ERROR: $1"; log_error "Installation aborted. L
 
 show_help() {
     cat << 'EOF'
-Usage: sudo bash install_amneziawg.sh [OPTIONS]
+Usage: sudo bash install_amneziawg_en.sh [OPTIONS]
 Script for automated installation and configuration of AmneziaWG 2.0 on Ubuntu 24.04.
 
 Options:
@@ -124,11 +124,11 @@ Options:
   -y, --yes             Auto-confirm (reboots, UFW, etc.)
 
 Examples:
-  sudo bash install_amneziawg.sh                             # Interactive installation
-  sudo bash install_amneziawg.sh --port=51820 --route-all    # Non-interactive
-  sudo bash install_amneziawg.sh --route-amnezia --yes       # Fully automated
-  sudo bash install_amneziawg.sh --uninstall                 # Uninstall
-  sudo bash install_amneziawg.sh --diagnostic                # Diagnostics
+  sudo bash install_amneziawg_en.sh                             # Interactive installation
+  sudo bash install_amneziawg_en.sh --port=51820 --route-all    # Non-interactive
+  sudo bash install_amneziawg_en.sh --route-amnezia --yes       # Fully automated
+  sudo bash install_amneziawg_en.sh --uninstall                 # Uninstall
+  sudo bash install_amneziawg_en.sh --diagnostic                # Diagnostics
 
 Repository: https://github.com/bivlked/amneziawg-installer
 EOF


### PR DESCRIPTION
## Summary

- Fixed `show_help()` in `install_amneziawg_en.sh` — examples referenced `install_amneziawg.sh` instead of `install_amneziawg_en.sh`, causing confusion when users copy commands from `--help`
- Added resume-after-reboot guidance in the English install block in `README.en.md` — users who download `_en.sh` now see the correct filename for re-running after reboots

Addresses automated review feedback from PR #10.

## Checklist

- [x] `bash -n` passes for all scripts
- [x] `shellcheck -s bash -S warning` passes
- [x] English script versions (`_en.sh`) synchronized

🤖 Generated with [Claude Code](https://claude.ai/code)