### PR TITLE
feat: add Raspberry Pi arm64 kernel header detection

### DIFF
--- a/.github/workflows/arm-build.yml
+++ b/.github/workflows/arm-build.yml
@@ -1,0 +1,146 @@
+name: ARM prebuilt kernel modules
+
+on:
+  workflow_dispatch:
+    inputs:
+      module_version:
+        description: 'amneziawg-linux-kernel-module tag (leave blank for latest)'
+        required: false
+        default: ''
+  push:
+    tags: ['v*']   # also rebuild on installer releases
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-arm-deb:
+    name: Build ${{ matrix.id }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+
+          # Raspberry Pi 4 / Pi 3 — arm64 (aarch64, Debian Bookworm)
+          - id: rpi-bookworm-arm64
+            platform: linux/arm64
+            image: debian:bookworm
+            extra_sources: rpi
+            headers_pkg: linux-headers-rpi-v8
+            arch: arm64
+
+          # Raspberry Pi 5 — arm64 (Cortex-A76, Debian Bookworm)
+          - id: rpi5-bookworm-arm64
+            platform: linux/arm64
+            image: debian:bookworm
+            extra_sources: rpi
+            headers_pkg: linux-headers-rpi-2712
+            arch: arm64
+
+          # Raspberry Pi 4 / Pi 3 — armhf (32-bit, Debian Bookworm)
+          - id: rpi-bookworm-armhf
+            platform: linux/arm/v7
+            image: debian:bookworm
+            extra_sources: rpi
+            headers_pkg: linux-headers-rpi-v7
+            arch: armhf
+
+          # Ubuntu 24.04 LTS — arm64 (Ampere A1, AWS Graviton, etc.)
+          - id: ubuntu-2404-arm64
+            platform: linux/arm64
+            image: ubuntu:24.04
+            extra_sources: ''
+            headers_pkg: linux-headers-generic
+            arch: arm64
+
+          # Ubuntu 22.04 LTS — arm64
+          - id: ubuntu-2204-arm64
+            platform: linux/arm64
+            image: ubuntu:22.04
+            extra_sources: ''
+            headers_pkg: linux-headers-generic
+            arch: arm64
+
+          # Debian 12 Bookworm — arm64 (mainline kernel, VPS/cloud)
+          - id: debian-bookworm-arm64
+            platform: linux/arm64
+            image: debian:bookworm
+            extra_sources: ''
+            headers_pkg: linux-headers-arm64
+            arch: arm64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: ${{ matrix.platform }}
+
+      - name: Build .deb in target container
+        env:
+          KERNEL_ID: ${{ matrix.id }}
+          EXTRA_SOURCES: ${{ matrix.extra_sources }}
+          HEADERS_PKG: ${{ matrix.headers_pkg }}
+          MODULE_VERSION: ${{ inputs.module_version }}
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ${{ matrix.image }}
+          options: >-
+            --platform ${{ matrix.platform }}
+            -v ${{ github.workspace }}:/workspace
+            -v /output:/output
+            -e KERNEL_ID
+            -e OUTPUT_DIR=/output
+            -e MODULE_VERSION
+          run: |
+            set -euo pipefail
+            export DEBIAN_FRONTEND=noninteractive
+
+            apt-get update -qq
+            apt-get install -y --no-install-recommends \
+              build-essential git curl gnupg ca-certificates \
+              kmod dkms dpkg-dev xz-utils
+
+            # Add Raspberry Pi Foundation apt repo if needed
+            if [[ "${EXTRA_SOURCES:-}" == "rpi" ]]; then
+              curl -fsSL https://archive.raspberrypi.com/debian/raspberrypi.gpg.key \
+                | gpg --dearmor -o /etc/apt/keyrings/raspberrypi.gpg
+              echo "deb [signed-by=/etc/apt/keyrings/raspberrypi.gpg] \
+                https://archive.raspberrypi.com/debian/ bookworm main" \
+                > /etc/apt/sources.list.d/raspberrypi.list
+              apt-get update -qq
+            fi
+
+            apt-get install -y --no-install-recommends "${HEADERS_PKG}"
+            mkdir -p /output
+            bash /workspace/scripts/build-arm-deb.sh
+
+      - name: List output
+        run: ls -lh /output/*.deb
+
+      - name: Upload to arm-packages release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Create or update the arm-packages release tag
+          if ! gh release view arm-packages --repo "${{ github.repository }}" &>/dev/null; then
+            gh release create arm-packages \
+              --repo "${{ github.repository }}" \
+              --title "ARM prebuilt kernel modules" \
+              --notes "Precompiled amneziawg.ko packages for ARM targets. Updated automatically on each installer release. See README for supported kernels." \
+              --prerelease
+          fi
+
+          # Upload (overwrite if exists)
+          for deb in /output/*.deb; do
+            gh release upload arm-packages "$deb" \
+              --repo "${{ github.repository }}" \
+              --clobber
+          done

--- a/.github/workflows/arm-build.yml
+++ b/.github/workflows/arm-build.yml
@@ -83,6 +83,9 @@ jobs:
         with:
           platforms: ${{ matrix.platform }}
 
+      - name: Prepare output dir
+        run: mkdir -p ${{ github.workspace }}/output
+
       - name: Build .deb in target container
         env:
           KERNEL_ID: ${{ matrix.id }}
@@ -95,7 +98,7 @@ jobs:
           options: >-
             --platform ${{ matrix.platform }}
             -v ${{ github.workspace }}:/workspace
-            -v /output:/output
+            -v ${{ github.workspace }}/output:/output
             -e KERNEL_ID
             -e OUTPUT_DIR=/output
             -e MODULE_VERSION
@@ -122,8 +125,14 @@ jobs:
             mkdir -p /output
             bash /workspace/scripts/build-arm-deb.sh
 
+      - name: Generate SHA256 checksums
+        run: |
+          for deb in ${{ github.workspace }}/output/*.deb; do
+            sha256sum "$deb" | awk '{print $1}' > "${deb}.sha256"
+          done
+
       - name: List output
-        run: ls -lh /output/*.deb
+        run: ls -lh ${{ github.workspace }}/output/
 
       - name: Upload to arm-packages release
         env:
@@ -138,9 +147,12 @@ jobs:
               --prerelease
           fi
 
-          # Upload (overwrite if exists)
-          for deb in /output/*.deb; do
+          # Upload .deb and .deb.sha256 (overwrite if exists)
+          for deb in ${{ github.workspace }}/output/*.deb; do
             gh release upload arm-packages "$deb" \
+              --repo "${{ github.repository }}" \
+              --clobber
+            gh release upload arm-packages "${deb}.sha256" \
               --repo "${{ github.repository }}" \
               --clobber
           done

--- a/install_amneziawg.sh
+++ b/install_amneziawg.sh
@@ -1605,8 +1605,21 @@ PPASRC
         packages+=("$current_headers")
     else
         log_warn "Нет headers для $(uname -r), установка общего пакета..."
-        if [[ "${OS_ID:-ubuntu}" == "debian" ]]; then
-            # На Debian: linux-headers-amd64 (или linux-headers-$(dpkg --print-architecture))
+        local kernel_release
+        kernel_release="$(uname -r)"
+        if [[ "$kernel_release" == *+rpt* || "$kernel_release" == *-rpi* ]]; then
+            # Ядро Raspberry Pi Foundation (+rpt suffix) — использовать мета-пакет RPi
+            # linux-headers-rpi-2712: Pi 5 / Cortex-A76; linux-headers-rpi-v8: Pi 3/4 arm64
+            local rpi_headers
+            if [[ "$kernel_release" == *2712* ]]; then
+                rpi_headers="linux-headers-rpi-2712"
+            else
+                rpi_headers="linux-headers-rpi-v8"
+            fi
+            log "Обнаружено ядро Raspberry Pi, используем $rpi_headers"
+            packages+=("$rpi_headers")
+        elif [[ "${OS_ID:-ubuntu}" == "debian" ]]; then
+            # На Debian: linux-headers-$(dpkg --print-architecture)
             local arch_pkg
             arch_pkg="linux-headers-$(dpkg --print-architecture 2>/dev/null || echo "amd64")"
             packages+=("$arch_pkg")

--- a/install_amneziawg.sh
+++ b/install_amneziawg.sh
@@ -1491,6 +1491,61 @@ step1_update_and_optimize() {
 }
 
 # ==============================================================================
+# Поддержка предсобранных пакетов для ARM
+# ==============================================================================
+
+# _try_install_prebuilt_arm — скачать и установить предсобранный .deb для
+# текущего ARM-ядра из релиза arm-packages на GitHub.
+#
+# Возвращает 0 при успехе, 1 если совпадений нет или установка не удалась
+# (в этом случае вызывающий код переходит к DKMS).
+_try_install_prebuilt_arm() {
+    local kernel arch target_id asset_name asset_url tmpfile
+    kernel="$(uname -r)"
+    arch="$(dpkg --print-architecture)"
+
+    if [[ "$kernel" == *+rpt-rpi-2712* ]]; then
+        target_id="rpi5-bookworm-arm64"
+    elif [[ "$kernel" == *+rpt* && "$arch" == "arm64" ]]; then
+        target_id="rpi-bookworm-arm64"
+    elif [[ "$kernel" == *+rpt* && "$arch" == "armhf" ]]; then
+        target_id="rpi-bookworm-armhf"
+    elif [[ "$kernel" == *-generic* && "${OS_VERSION:-}" == "24.04" ]]; then
+        target_id="ubuntu-2404-arm64"
+    elif [[ "$kernel" == *-generic* && "${OS_VERSION:-}" == "22.04" ]]; then
+        target_id="ubuntu-2204-arm64"
+    elif [[ "$kernel" == *-arm64* && "${OS_ID:-}" == "debian" ]]; then
+        target_id="debian-bookworm-arm64"
+    else
+        log "Предсобранный пакет для ядра $kernel ($arch) не найден"
+        return 1
+    fi
+
+    asset_name="amneziawg-kmod-${target_id}_${kernel}_${arch}.deb"
+    asset_url="https://github.com/bivlked/amneziawg-installer/releases/download/arm-packages/${asset_name}"
+
+    log "Попытка установки предсобранного пакета: $asset_name"
+    tmpfile="$(mktemp /tmp/amneziawg-prebuilt-XXXXXX.deb)"
+
+    if curl -fsSL --retry 2 --connect-timeout 10 -o "$tmpfile" "$asset_url" 2>/dev/null; then
+        log "Пакет скачан, установка..."
+        if dpkg -i "$tmpfile" 2>/dev/null; then
+            rm -f "$tmpfile"
+            log "Предсобранный пакет установлен: $asset_name"
+            return 0
+        else
+            log_warn "Ошибка установки (несовпадение vermagic или повреждённый пакет)"
+            rm -f "$tmpfile"
+            return 1
+        fi
+    else
+        log "Предсобранный пакет недоступен для $kernel — используется DKMS"
+        rm -f "$tmpfile"
+        return 1
+    fi
+}
+
+# ==============================================================================
 # ШАГ 2: Установка AmneziaWG и зависимостей
 # ==============================================================================
 
@@ -1595,6 +1650,20 @@ PPASRC
 
     # Пакеты AmneziaWG + qrencode (БЕЗ Python!)
     log "Установка пакетов AmneziaWG..."
+
+    # На ARM: сначала пробуем предсобранный .deb (не требует build-tools и headers).
+    # Откат на DKMS если совпадения нет или скачивание не удалось.
+    local arch
+    arch="$(uname -m)"
+    if [[ "$arch" == "aarch64" || "$arch" == "armv7l" ]]; then
+        if _try_install_prebuilt_arm; then
+            log "Модуль ядра установлен из предсобранного пакета. Установка утилит из PPA..."
+            install_packages "amneziawg-tools" "wireguard-tools" "qrencode"
+            return
+        fi
+        log "Совпадений не найдено — откат на DKMS."
+    fi
+
     local packages=("amneziawg-dkms" "amneziawg-tools" "wireguard-tools" "dkms"
                     "build-essential" "dpkg-dev" "qrencode")
 

--- a/install_amneziawg.sh
+++ b/install_amneziawg.sh
@@ -1500,7 +1500,7 @@ step1_update_and_optimize() {
 # Возвращает 0 при успехе, 1 если совпадений нет или установка не удалась
 # (в этом случае вызывающий код переходит к DKMS).
 _try_install_prebuilt_arm() {
-    local kernel arch target_id asset_name asset_url tmpfile
+    local kernel arch target_id asset_name asset_url tmpfile tmpsha expected_sha actual_sha
     kernel="$(uname -r)"
     arch="$(dpkg --print-architecture)"
 
@@ -1526,9 +1526,29 @@ _try_install_prebuilt_arm() {
 
     log "Попытка установки предсобранного пакета: $asset_name"
     tmpfile="$(mktemp /tmp/amneziawg-prebuilt-XXXXXX.deb)"
+    tmpsha="$(mktemp /tmp/amneziawg-prebuilt-XXXXXX.deb.sha256)"
 
-    if curl -fsSL --retry 2 --connect-timeout 10 -o "$tmpfile" "$asset_url" 2>/dev/null; then
-        log "Пакет скачан, установка..."
+    # Сначала скачиваем контрольную сумму SHA256
+    if ! curl -fsSL --retry 2 --connect-timeout 10 --max-time 60 \
+            -o "$tmpsha" "${asset_url}.sha256" 2>/dev/null; then
+        log "Предсобранный пакет недоступен для $kernel — используется DKMS"
+        rm -f "$tmpfile" "$tmpsha"
+        return 1
+    fi
+
+    if curl -fsSL --retry 2 --connect-timeout 10 --max-time 60 \
+            -o "$tmpfile" "$asset_url" 2>/dev/null; then
+        # Проверяем целостность перед установкой модуля ядра
+        expected_sha="$(cat "$tmpsha")"
+        actual_sha="$(sha256sum "$tmpfile" | awk '{print $1}')"
+        rm -f "$tmpsha"
+        if [[ "$expected_sha" != "$actual_sha" ]]; then
+            log_warn "Несовпадение SHA256 предсобранного пакета — скачивание отклонено"
+            rm -f "$tmpfile"
+            return 1
+        fi
+
+        log "Пакет скачан (SHA256 OK), установка..."
         if dpkg -i "$tmpfile" 2>/dev/null; then
             rm -f "$tmpfile"
             log "Предсобранный пакет установлен: $asset_name"
@@ -1540,7 +1560,7 @@ _try_install_prebuilt_arm() {
         fi
     else
         log "Предсобранный пакет недоступен для $kernel — используется DKMS"
-        rm -f "$tmpfile"
+        rm -f "$tmpfile" "$tmpsha"
         return 1
     fi
 }

--- a/install_amneziawg_en.sh
+++ b/install_amneziawg_en.sh
@@ -1606,8 +1606,21 @@ PPASRC
         packages+=("$current_headers")
     else
         log_warn "No headers for $(uname -r), installing generic package..."
-        if [[ "${OS_ID:-ubuntu}" == "debian" ]]; then
-            # On Debian: linux-headers-amd64 (or linux-headers-$(dpkg --print-architecture))
+        local kernel_release
+        kernel_release="$(uname -r)"
+        if [[ "$kernel_release" == *+rpt* || "$kernel_release" == *-rpi* ]]; then
+            # Raspberry Pi Foundation kernel (+rpt suffix) — use RPi meta-package
+            # linux-headers-rpi-2712: Pi 5 / Cortex-A76; linux-headers-rpi-v8: Pi 3/4 arm64
+            local rpi_headers
+            if [[ "$kernel_release" == *2712* ]]; then
+                rpi_headers="linux-headers-rpi-2712"
+            else
+                rpi_headers="linux-headers-rpi-v8"
+            fi
+            log "Raspberry Pi kernel detected, using $rpi_headers"
+            packages+=("$rpi_headers")
+        elif [[ "${OS_ID:-ubuntu}" == "debian" ]]; then
+            # On Debian: linux-headers-$(dpkg --print-architecture)
             local arch_pkg
             arch_pkg="linux-headers-$(dpkg --print-architecture 2>/dev/null || echo "amd64")"
             packages+=("$arch_pkg")

--- a/install_amneziawg_en.sh
+++ b/install_amneziawg_en.sh
@@ -1492,6 +1492,70 @@ step1_update_and_optimize() {
 }
 
 # ==============================================================================
+# ARM prebuilt support
+# ==============================================================================
+
+# _try_install_prebuilt_arm — download and install a prebuilt amneziawg .deb
+# for the current ARM kernel from the arm-packages GitHub release.
+#
+# Returns 0 if a matching prebuilt was installed successfully.
+# Returns 1 if no match was found or installation failed (caller falls back to DKMS).
+#
+# Prebuilt packages are built by .github/workflows/arm-build.yml and published
+# to the arm-packages release tag. The filename encodes both the target ID and
+# the exact kernel version: amneziawg-kmod-<target-id>_<kernel-version>_<arch>.deb
+#
+# Kernel version matching is exact — the module vermagic must match uname -r.
+# DKMS is the preferred path for kernels that haven't been pre-built yet.
+_try_install_prebuilt_arm() {
+    local kernel arch target_id asset_name asset_url tmpfile
+    kernel="$(uname -r)"
+    arch="$(dpkg --print-architecture)"
+
+    # Map kernel string to a build target ID
+    if [[ "$kernel" == *+rpt-rpi-2712* ]]; then
+        target_id="rpi5-bookworm-arm64"
+    elif [[ "$kernel" == *+rpt* && "$arch" == "arm64" ]]; then
+        target_id="rpi-bookworm-arm64"
+    elif [[ "$kernel" == *+rpt* && "$arch" == "armhf" ]]; then
+        target_id="rpi-bookworm-armhf"
+    elif [[ "$kernel" == *-generic* && "${OS_VERSION:-}" == "24.04" ]]; then
+        target_id="ubuntu-2404-arm64"
+    elif [[ "$kernel" == *-generic* && "${OS_VERSION:-}" == "22.04" ]]; then
+        target_id="ubuntu-2204-arm64"
+    elif [[ "$kernel" == *-arm64* && "${OS_ID:-}" == "debian" ]]; then
+        target_id="debian-bookworm-arm64"
+    else
+        log "No prebuilt target for kernel $kernel ($arch)"
+        return 1
+    fi
+
+    # Asset filename encodes the exact kernel version
+    asset_name="amneziawg-kmod-${target_id}_${kernel}_${arch}.deb"
+    asset_url="https://github.com/bivlked/amneziawg-installer/releases/download/arm-packages/${asset_name}"
+
+    log "Trying prebuilt: $asset_name"
+    tmpfile="$(mktemp /tmp/amneziawg-prebuilt-XXXXXX.deb)"
+
+    if curl -fsSL --retry 2 --connect-timeout 10 -o "$tmpfile" "$asset_url" 2>/dev/null; then
+        log "Downloaded prebuilt, installing..."
+        if dpkg -i "$tmpfile" 2>/dev/null; then
+            rm -f "$tmpfile"
+            log "Prebuilt installed: $asset_name"
+            return 0
+        else
+            log_warn "Prebuilt install failed (vermagic mismatch or corrupt package)"
+            rm -f "$tmpfile"
+            return 1
+        fi
+    else
+        log "Prebuilt not available for $kernel — using DKMS"
+        rm -f "$tmpfile"
+        return 1
+    fi
+}
+
+# ==============================================================================
 # STEP 2: Installing AmneziaWG and dependencies
 # ==============================================================================
 
@@ -1596,6 +1660,20 @@ PPASRC
 
     # AmneziaWG + qrencode packages (NO Python!)
     log "Installing AmneziaWG packages..."
+
+    # On ARM: try prebuilt .deb first (no build tools or headers required).
+    # Falls back to DKMS if no matching prebuilt is available or download fails.
+    local arch
+    arch="$(uname -m)"
+    if [[ "$arch" == "aarch64" || "$arch" == "armv7l" ]]; then
+        if _try_install_prebuilt_arm; then
+            log "Prebuilt kernel module installed. Installing userspace tools from PPA..."
+            install_packages "amneziawg-tools" "wireguard-tools" "qrencode"
+            return
+        fi
+        log "No matching prebuilt — falling back to DKMS build."
+    fi
+
     local packages=("amneziawg-dkms" "amneziawg-tools" "wireguard-tools" "dkms"
                     "build-essential" "dpkg-dev" "qrencode")
 

--- a/install_amneziawg_en.sh
+++ b/install_amneziawg_en.sh
@@ -1508,7 +1508,7 @@ step1_update_and_optimize() {
 # Kernel version matching is exact — the module vermagic must match uname -r.
 # DKMS is the preferred path for kernels that haven't been pre-built yet.
 _try_install_prebuilt_arm() {
-    local kernel arch target_id asset_name asset_url tmpfile
+    local kernel arch target_id asset_name asset_url tmpfile tmpsha expected_sha actual_sha
     kernel="$(uname -r)"
     arch="$(dpkg --print-architecture)"
 
@@ -1536,9 +1536,29 @@ _try_install_prebuilt_arm() {
 
     log "Trying prebuilt: $asset_name"
     tmpfile="$(mktemp /tmp/amneziawg-prebuilt-XXXXXX.deb)"
+    tmpsha="$(mktemp /tmp/amneziawg-prebuilt-XXXXXX.deb.sha256)"
 
-    if curl -fsSL --retry 2 --connect-timeout 10 -o "$tmpfile" "$asset_url" 2>/dev/null; then
-        log "Downloaded prebuilt, installing..."
+    # Download SHA256 checksum first
+    if ! curl -fsSL --retry 2 --connect-timeout 10 --max-time 60 \
+            -o "$tmpsha" "${asset_url}.sha256" 2>/dev/null; then
+        log "Prebuilt not available for $kernel — using DKMS"
+        rm -f "$tmpfile" "$tmpsha"
+        return 1
+    fi
+
+    if curl -fsSL --retry 2 --connect-timeout 10 --max-time 60 \
+            -o "$tmpfile" "$asset_url" 2>/dev/null; then
+        # Verify integrity before installing a kernel module
+        expected_sha="$(cat "$tmpsha")"
+        actual_sha="$(sha256sum "$tmpfile" | awk '{print $1}')"
+        rm -f "$tmpsha"
+        if [[ "$expected_sha" != "$actual_sha" ]]; then
+            log_warn "Prebuilt SHA256 mismatch — discarding download"
+            rm -f "$tmpfile"
+            return 1
+        fi
+
+        log "Downloaded prebuilt (SHA256 OK), installing..."
         if dpkg -i "$tmpfile" 2>/dev/null; then
             rm -f "$tmpfile"
             log "Prebuilt installed: $asset_name"
@@ -1550,7 +1570,7 @@ _try_install_prebuilt_arm() {
         fi
     else
         log "Prebuilt not available for $kernel — using DKMS"
-        rm -f "$tmpfile"
+        rm -f "$tmpfile" "$tmpsha"
         return 1
     fi
 }

--- a/scripts/build-arm-deb.sh
+++ b/scripts/build-arm-deb.sh
@@ -109,3 +109,7 @@ DEB_FILE="${OUTPUT_DIR}/${PKG_NAME}_${KERNEL_VERSION}_${ARCH}.deb"
 dpkg-deb --build "$DEB_DIR" "$DEB_FILE"
 echo "--- Built: $DEB_FILE ---"
 ls -lh "$DEB_FILE"
+
+# Generate SHA256 checksum alongside the .deb
+sha256sum "$DEB_FILE" | awk '{print $1}' > "${DEB_FILE}.sha256"
+echo "SHA256: $(cat "${DEB_FILE}.sha256")"

--- a/scripts/build-arm-deb.sh
+++ b/scripts/build-arm-deb.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# build-arm-deb.sh — Build amneziawg kernel module and package as .deb
+#
+# Usage (environment variables):
+#   KERNEL_ID       Target ID (e.g. rpi-bookworm-arm64). Used in .deb package name.
+#   OUTPUT_DIR      Directory to write the .deb file. Default: /output
+#   MODULE_VERSION  amneziawg module version tag. Default: latest tag from upstream.
+#
+# The script:
+#   1. Detects the installed kernel headers and resolves the exact kernel version
+#   2. Clones amneziawg-linux-kernel-module and builds amneziawg.ko
+#   3. Packages the .ko into a .deb with a postinst that runs depmod
+#   4. Writes the .deb to OUTPUT_DIR
+#
+# Output filename: amneziawg-kmod-${KERNEL_ID}_${KERNEL_VERSION}_${ARCH}.deb
+# e.g.            amneziawg-kmod-rpi-bookworm-arm64_6.12.75+rpt-rpi-v8_arm64.deb
+
+set -euo pipefail
+
+KERNEL_ID="${KERNEL_ID:?KERNEL_ID must be set}"
+OUTPUT_DIR="${OUTPUT_DIR:-/output}"
+MODULE_REPO="https://github.com/amnezia-vpn/amneziawg-linux-kernel-module.git"
+MODULE_VERSION="${MODULE_VERSION:-}"
+
+echo "=== amneziawg ARM .deb builder ==="
+echo "KERNEL_ID: $KERNEL_ID"
+echo "Running as: $(uname -a)"
+
+# Resolve exact kernel version from installed headers
+KERNEL_VERSION="$(ls /lib/modules/ | head -1)"
+if [[ -z "$KERNEL_VERSION" ]]; then
+    echo "ERROR: No kernel headers found under /lib/modules/" >&2
+    exit 1
+fi
+echo "Kernel version: $KERNEL_VERSION"
+
+ARCH="$(dpkg --print-architecture)"
+echo "Architecture: $ARCH"
+
+# Verify build tools are available
+for cmd in make gcc git dpkg-deb depmod; do
+    command -v "$cmd" &>/dev/null || { echo "ERROR: $cmd not found" >&2; exit 1; }
+done
+
+# Clone module source
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "--- Cloning amneziawg-linux-kernel-module ---"
+git clone --depth=1 ${MODULE_VERSION:+--branch "$MODULE_VERSION"} \
+    "$MODULE_REPO" "$WORK_DIR/src"
+
+# Build
+echo "--- Building kernel module ---"
+make -C "/lib/modules/${KERNEL_VERSION}/build" \
+    M="$WORK_DIR/src" \
+    modules
+
+KO_PATH="$WORK_DIR/src/amneziawg.ko"
+if [[ ! -f "$KO_PATH" ]]; then
+    echo "ERROR: amneziawg.ko not found after build" >&2
+    exit 1
+fi
+
+# Verify vermagic matches the target kernel
+VERMAGIC="$(modinfo "$KO_PATH" | awk '/^vermagic:/{print $2}')"
+echo "Module vermagic: $VERMAGIC"
+if [[ "$VERMAGIC" != "$KERNEL_VERSION" ]]; then
+    echo "ERROR: vermagic mismatch (got $VERMAGIC, expected $KERNEL_VERSION)" >&2
+    exit 1
+fi
+
+MODULE_VER="$(modinfo "$KO_PATH" | awk '/^version:/{print $2}')"
+echo "Module version: $MODULE_VER"
+
+# Package as .deb
+PKG_NAME="amneziawg-kmod-${KERNEL_ID}"
+PKG_VERSION="${MODULE_VER}-${KERNEL_VERSION//+/\~}"   # dpkg-safe: + → ~
+DEB_DIR="$WORK_DIR/deb"
+MODULE_INSTALL_PATH="${DEB_DIR}/lib/modules/${KERNEL_VERSION}/extra"
+
+mkdir -p "$MODULE_INSTALL_PATH" "${DEB_DIR}/DEBIAN"
+
+cp "$KO_PATH" "$MODULE_INSTALL_PATH/amneziawg.ko"
+xz -9 "$MODULE_INSTALL_PATH/amneziawg.ko" 2>/dev/null || true  # compress if xz available
+
+cat > "${DEB_DIR}/DEBIAN/control" <<EOF
+Package: ${PKG_NAME}
+Version: ${PKG_VERSION}
+Architecture: ${ARCH}
+Maintainer: amneziawg-installer contributors
+Description: AmneziaWG kernel module (prebuilt for ${KERNEL_ID})
+ Precompiled amneziawg.ko for kernel ${KERNEL_VERSION}.
+ Target: ${KERNEL_ID}
+ Built from: amnezia-vpn/amneziawg-linux-kernel-module
+EOF
+
+cat > "${DEB_DIR}/DEBIAN/postinst" <<'POSTINST'
+#!/bin/sh
+set -e
+depmod -a
+exit 0
+POSTINST
+chmod 755 "${DEB_DIR}/DEBIAN/postinst"
+
+mkdir -p "$OUTPUT_DIR"
+DEB_FILE="${OUTPUT_DIR}/${PKG_NAME}_${KERNEL_VERSION}_${ARCH}.deb"
+
+dpkg-deb --build "$DEB_DIR" "$DEB_FILE"
+echo "--- Built: $DEB_FILE ---"
+ls -lh "$DEB_FILE"

--- a/tests/test_rpi_headers.bats
+++ b/tests/test_rpi_headers.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+# Tests for Raspberry Pi kernel header detection in install_amneziawg.sh
+# Validates that the correct linux-headers-rpi-* meta-package is selected
+# when the exact linux-headers-$(uname -r) package is unavailable.
+
+load test_helper
+
+# Extract just the headers-detection logic into a testable function by
+# re-implementing it here with injectable mock stubs (uname, dpkg, apt-cache).
+# This avoids sourcing the full installer (which has root-only side effects).
+
+select_rpi_headers() {
+    # Args: $1 = simulated kernel string (e.g. "6.12.75+rpt-rpi-v8")
+    local kernel_release="$1"
+    local current_headers="linux-headers-${kernel_release}"
+
+    # Simulate dpkg -s / apt-cache show both failing (headers not installed)
+    if false; then
+        echo "$current_headers"
+        return
+    fi
+
+    if [[ "$kernel_release" == *+rpt* || "$kernel_release" == *-rpi* ]]; then
+        if [[ "$kernel_release" == *2712* ]]; then
+            echo "linux-headers-rpi-2712"
+        else
+            echo "linux-headers-rpi-v8"
+        fi
+    else
+        echo "linux-headers-$(dpkg --print-architecture 2>/dev/null || echo "amd64")"
+    fi
+}
+
+@test "rpi headers: Pi 3/4 arm64 rpt kernel selects rpi-v8" {
+    result=$(select_rpi_headers "6.12.75+rpt-rpi-v8")
+    [ "$result" = "linux-headers-rpi-v8" ]
+}
+
+@test "rpi headers: Pi 5 rpt-rpi-2712 kernel selects rpi-2712" {
+    result=$(select_rpi_headers "6.12.75+rpt-rpi-2712")
+    [ "$result" = "linux-headers-rpi-2712" ]
+}
+
+@test "rpi headers: older rpi- suffix kernel selects rpi-v8" {
+    result=$(select_rpi_headers "6.6.31-rpi-v8")
+    [ "$result" = "linux-headers-rpi-v8" ]
+}
+
+@test "rpi headers: non-RPi arm64 debian kernel selects arch package" {
+    result=$(select_rpi_headers "6.1.0-28-arm64")
+    [ "$result" = "linux-headers-arm64" ]
+}
+
+@test "rpi headers: amd64 x86 kernel selects amd64 package" {
+    result=$(select_rpi_headers "6.1.0-28-amd64")
+    [ "$result" = "linux-headers-amd64" ]
+}
+
+@test "rpi headers: generic Ubuntu kernel selects arch package" {
+    result=$(select_rpi_headers "6.8.0-57-generic")
+    # Should not match RPi pattern
+    [[ "$result" != *rpi* ]]
+}


### PR DESCRIPTION
## Summary

Full implementation of ARM support as proposed in #37, covering prebuilt packages, CI build pipeline, and DKMS fallback with correct header detection.

---

## What this PR adds

### 1. GitHub Actions build matrix (`.github/workflows/arm-build.yml`)

Builds `amneziawg.ko` for 6 ARM targets using QEMU emulation. Triggered on each `v*` tag push and via manual dispatch. Publishes `.deb` files to an `arm-packages` release tag.

| Target ID | Platform | Image | Headers package |
|---|---|---|---|
| `rpi-bookworm-arm64` | linux/arm64 | debian:bookworm | linux-headers-rpi-v8 |
| `rpi5-bookworm-arm64` | linux/arm64 | debian:bookworm | linux-headers-rpi-2712 |
| `rpi-bookworm-armhf` | linux/arm/v7 | debian:bookworm | linux-headers-rpi-v7 |
| `ubuntu-2404-arm64` | linux/arm64 | ubuntu:24.04 | linux-headers-generic |
| `ubuntu-2204-arm64` | linux/arm64 | ubuntu:22.04 | linux-headers-generic |
| `debian-bookworm-arm64` | linux/arm64 | debian:bookworm | linux-headers-arm64 |

RPi targets add the RPi Foundation apt repo (`archive.raspberrypi.com`) to get the correct headers. All other targets use standard distribution headers.

### 2. Build script (`scripts/build-arm-deb.sh`)

Builds the kernel module against installed headers, verifies vermagic matches the target kernel, and packages as `amneziawg-kmod-<target-id>_<kernel-version>_<arch>.deb`. Can be run manually on ARM hardware as well as in CI.

### 3. Prebuilt installer integration (both `.sh` files)

On ARM (`aarch64`/`armv7l`), step 2 now tries the prebuilt path before DKMS:

```
ARM detected
  → match uname -r to target ID
  → download amneziawg-kmod-<target-id>_<kernel>_<arch>.deb from arm-packages release
  → dpkg -i (vermagic mismatch → silent failure)
  → success: install amneziawg-tools + wireguard-tools from PPA (no build tools needed)
  → failure/no match: fall back to DKMS (existing behavior, unchanged)
```

### 4. DKMS fallback header detection fix

When the prebuilt path is skipped or fails and DKMS is used, the kernel headers fallback now correctly handles Raspberry Pi kernels (`+rpt`/`-rpi` suffix) by selecting `linux-headers-rpi-v8` or `linux-headers-rpi-2712` instead of the non-existent `linux-headers-arm64` package.

---

## Notes on the prebuilt approach

**Kernel version matching is exact.** The `.deb` filename encodes the specific kernel version (e.g. `amneziawg-kmod-rpi-bookworm-arm64_6.12.75+rpt-rpi-v8_arm64.deb`). If the user's kernel doesn't match a built asset, the installer falls through to DKMS silently.

**Refresh cadence.** Prebuilts are rebuilt on each installer release tag. Users on a kernel that post-dates the last release will use DKMS. This is intentional — DKMS is the robust fallback; prebuilts are an optimisation for minimal systems without build tools.

**`amneziawg-tools` (awg/awg-quick) on ARM.** The PPA already publishes arm64 and armhf builds for `amneziawg-tools`. No separate build pipeline is needed for the userspace tools.

---

## Test results

Tested on Raspberry Pi 4, Debian 12 Bookworm, kernel `6.12.75+rpt-rpi-v8`, arm64 (DKMS path — prebuilts not yet published):

```
filename: /lib/modules/6.12.75+rpt-rpi-v8/updates/dkms/amneziawg.ko.xz
vermagic:  6.12.75+rpt-rpi-v8 SMP preempt mod_unload modversions aarch64
VerMagic matches.
awg version: amneziawg-tools v1.0.20210914
Service: awg-quick@awg0 active
```

Full install completed end-to-end. Existing WireGuard interfaces (wg0, wg1) unaffected.

---

## Out of scope for this PR

- OpenWrt support (separate package ecosystem, needs OpenWrt SDK)
- Auto-tracking kernel updates / broken-package detection
- Armbian / other SBC vendor kernel detection (follow-up)

Closes #37