### PR TITLE
docs: add LXC/amneziawg-go userspace section to ADVANCED (#51)

### DIFF
--- a/ADVANCED.en.md
+++ b/ADVANCED.en.md
@@ -43,6 +43,7 @@ This is a supplement to the main [README.en.md](README.en.md), containing deeper
 - [📋 AWG 2.0 Client Compatibility](#client-compat-adv)
 - [🐧 Debian Support](#debian-support-adv)
 - [🔧 Raspberry Pi and ARM64 Support](#arm-support-adv)
+- [📦 LXC / Docker via amneziawg-go (userspace)](#lxc-userspace-adv)
 - [⚠️ Known Limitations](#limitations-adv)
 - [🤝 Contributing](#contributing-adv)
 - [💖 Acknowledgements](#thanks-adv)
@@ -957,10 +958,139 @@ Look for <code>Prebuilt module installed</code> in the install log (<code>/root/
 
 ---
 
+<a id="lxc-userspace-adv"></a>
+## 📦 LXC / Docker via amneziawg-go (userspace)
+
+If the **AmneziaWG kernel module cannot be installed on the host** — provider restriction, shared-kernel LXC without host privileges, or a shared Proxmox running other containers that you don't want to reboot for a DKMS build — there is an alternative: the [`amneziawg-go`](https://github.com/amnezia-vpn/amneziawg-go) userspace implementation. It is a TUN-backed build that does not need a kernel module. Throughput is lower than kernel-native (~30–50% CPU overhead at 1 Gbps), but it runs on any Linux with `/dev/net/tun`.
+
+My installer `install_amneziawg.sh` **does not cover this path** — I deliberately ship kernel-native for performance and to avoid pulling a Go compiler onto a production server. This section describes a manual setup on top of a running Debian / Ubuntu LXC.
+
+### ⚠️ Security tradeoff
+
+Running `amneziawg-go` inside LXC usually requires:
+
+- A **privileged container** (root mapped to host) or an `unprivileged` one with `/dev/net/tun` passthrough and `CAP_NET_ADMIN` — both give the container broad access to the host network stack.
+- **Nesting** (`features: nesting=1` on Proxmox) — needed for `iptables` inside the container. On Proxmox 9 with Debian 13 LXC (systemd 257+) Proxmox itself warns at container creation: `WARN: Systemd 257 detected. You may need to enable nesting.` — without nesting the container also stalls at the systemd level.
+- **tun passthrough** via `lxc.cgroup2.devices.allow` plus a bind-mount of `/dev/net`.
+
+If container isolation is critical (multi-tenant host, privacy-sensitive workload), use a KVM/QEMU VM with the regular installer instead of LXC.
+
+### LXC host requirements
+
+**Proxmox LXC config** (`/etc/pve/lxc/<VMID>.conf`):
+
+```conf
+features: nesting=1
+lxc.cgroup2.devices.allow: c 10:200 rwm
+lxc.mount.entry: /dev/net dev/net none bind,create=dir
+```
+
+Restart the container after editing the config: `pct stop <VMID> && pct start <VMID>`.
+
+**Forwarding inside the container:**
+
+```bash
+echo 'net.ipv4.ip_forward=1' | sudo tee /etc/sysctl.d/99-awg-forwarding.conf
+sudo sysctl --system
+```
+
+### Installing amneziawg-go and amneziawg-tools
+
+**Option 1 (faster): prebuilt binary from releases.** Download the prebuilt binary, no Go toolchain needed:
+
+```bash
+# Check the latest version: https://github.com/amnezia-vpn/amneziawg-go/releases
+AWG_GO_VERSION="0.2.15"
+ARCH="amd64"  # or arm64 for ARM VPS
+sudo apt install -y iptables git make
+sudo curl -fsSL \
+  "https://github.com/amnezia-vpn/amneziawg-go/releases/download/v${AWG_GO_VERSION}/amneziawg-go-linux-${ARCH}" \
+  -o /usr/local/bin/amneziawg-go
+sudo chmod +x /usr/local/bin/amneziawg-go
+```
+
+**Option 2: build from source.** Requires Go 1.21+. On Debian 12 the system `golang-go` is 1.19, so either install from backports or drop in Go manually:
+
+```bash
+sudo apt install -y golang-go git make iptables
+git clone https://github.com/amnezia-vpn/amneziawg-go
+cd amneziawg-go && make && sudo make install
+cd ..
+```
+
+**amneziawg-tools** provide the `awg` and `awg-quick` CLI. The system `awg-quick` from `wireguard-tools` does not understand the obfuscation parameters (`Jc/Jmin/Jmax/S1-S4/H1-H4/I1-I5`), so this fork is required:
+
+```bash
+git clone https://github.com/amnezia-vpn/amneziawg-tools
+cd amneziawg-tools/src && make && sudo make install
+cd ../..
+```
+
+### Config and launch
+
+Create `/etc/amnezia/amneziawg/awg0.conf` — replace the `YOUR_*` values with your own. Generate keys with `awg genkey | tee /etc/amnezia/amneziawg/server_private.key | awg pubkey`. Obfuscation params (`Jc/Jmin/Jmax/S1-S4/H1-H4/I1`) must match the client:
+
+```conf
+[Interface]
+Address = 10.9.9.1/24
+ListenPort = 39743
+PrivateKey = YOUR_SERVER_PRIVATE_KEY
+Jc = 4
+Jmin = 50
+Jmax = 150
+S1 = 0
+S2 = 0
+H1 = 1234567890
+H2 = 2345678901
+H3 = 3456789012
+H4 = 4012345678
+PostUp   = iptables -I INPUT   -p udp --dport 39743 -j ACCEPT
+PostUp   = iptables -I FORWARD -i eth0 -o awg0      -j ACCEPT
+PostUp   = iptables -I FORWARD -i awg0              -j ACCEPT
+PostUp   = iptables -t nat -A POSTROUTING -o eth0   -j MASQUERADE
+PostDown = iptables -D INPUT   -p udp --dport 39743 -j ACCEPT
+PostDown = iptables -D FORWARD -i eth0 -o awg0      -j ACCEPT
+PostDown = iptables -D FORWARD -i awg0              -j ACCEPT
+PostDown = iptables -t nat -D POSTROUTING -o eth0   -j MASQUERADE
+
+[Peer]
+PublicKey    = YOUR_CLIENT_PUBLIC_KEY
+PresharedKey = YOUR_PRESHARED_KEY
+AllowedIPs   = 10.9.9.2/32
+```
+
+Swap the interface name (`awg0`) and external NIC (`eth0`) for yours. For IPv6 add symmetric `ip6tables` rules. `ListenPort` must be open at the host level (UFW or host iptables) and at the cloud-provider level.
+
+Smoke test:
+
+```bash
+sudo awg-quick up awg0
+sudo awg                 # should show the interface and peers
+sudo awg-quick down awg0
+```
+
+Run as a systemd service:
+
+```bash
+sudo systemctl enable awg-quick@awg0
+sudo systemctl start awg-quick@awg0
+sudo systemctl status awg-quick@awg0
+```
+
+### Does `manage_amneziawg.sh` work on top?
+
+My `manage_amneziawg.sh` targets a kernel-native setup (expects `/etc/amnezia/amneziawg/awgsetup_cfg.init`, relies on `awg-quick` + `awg` from `amneziawg-tools`). In theory it should work on top of a manual `amneziawg-go` + `amneziawg-tools` install, provided the interface is named `awg0` and `/etc/amnezia/amneziawg/` exists. I **do not test or support this path** — for full client management either edit configs manually or pick a userspace-oriented tool.
+
+### Source
+
+The minimal working recipe for Debian 13 in a privileged LXC on Proxmox was shared by [@Akh-commits](https://github.com/Akh-commits) in [issue #51](https://github.com/bivlked/amneziawg-installer/issues/51#issuecomment-4288953829) — this section builds on it with additions covering the prebuilt path, the security warning, and the Debian 12 Go nuances.
+
+---
+
 <a id="limitations-adv"></a>
 ## ⚠️ Known Limitations
 
-* **LXC containers are not supported.** AmneziaWG requires a kernel module (DKMS). LXC shares the host kernel — loading a custom module from inside a container is not possible. Use a full VM or bare-metal server.
+* **LXC containers are not supported by my installer.** AmneziaWG requires a kernel module (DKMS). LXC shares the host kernel — loading a custom module from inside a container is not possible. Options: a full VM (KVM/QEMU) or a bare-metal server for a kernel-native setup, or the `amneziawg-go` userspace implementation inside LXC (see [LXC / Docker via amneziawg-go](#lxc-userspace-adv)).
 
 * **Assumes a dedicated server.** The script configures UFW, Fail2Ban, sysctl and optimizes the system for VPN. On servers running other services, use `--no-tweaks` to skip hardening.
 

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -43,6 +43,7 @@
 - [📋 Совместимость клиентов AWG 2.0](#client-compat-adv)
 - [🐧 Поддержка Debian](#debian-support-adv)
 - [🔧 Raspberry Pi и ARM64](#arm-support-adv)
+- [📦 LXC / Docker через amneziawg-go (userspace)](#lxc-userspace-adv)
 - [⚠️ Известные ограничения](#limitations-adv)
 - [🤝 Внесение вклада (Contributing)](#contributing-adv)
 - [💖 Благодарности](#thanks-adv)
@@ -955,10 +956,139 @@ Raspberry Pi 3 имеет 1 ГБ RAM и 4 ядра на 1.2 ГГц. Компил
 
 ---
 
+<a id="lxc-userspace-adv"></a>
+## 📦 LXC / Docker через amneziawg-go (userspace)
+
+Если **кернел-модуль AmneziaWG нельзя установить на хост** — запрет провайдера, shared-kernel LXC без root-доступа к хосту, общий Proxmox с другими контейнерами, который не хочется перезагружать ради DKMS-сборки, — есть альтернатива: userspace-реализация [`amneziawg-go`](https://github.com/amnezia-vpn/amneziawg-go). Это TUN-backed вариант, модуль ядра не нужен. Производительность ниже kernel-native (~30–50% CPU overhead на 1 Gbps), зато работает в любом Linux с `/dev/net/tun`.
+
+Мой инсталлятор `install_amneziawg.sh` **этот путь не покрывает** — я специально ставлю kernel-native ради производительности и чтобы не тащить Go-компилятор на prod. Раздел описывает ручную настройку поверх готового Debian / Ubuntu в LXC.
+
+### ⚠️ Security tradeoff
+
+Для работы `amneziawg-go` внутри LXC обычно требуется:
+
+- **Privileged контейнер** (root мапится на хост) или `unprivileged` с пробросом `/dev/net/tun` и `CAP_NET_ADMIN` — в обоих случаях контейнер получает широкий доступ к сетевому стеку хоста.
+- **Nesting** (`features: nesting=1` в Proxmox) — нужен для `iptables` внутри контейнера. На Proxmox 9 с Debian 13 LXC (systemd 257+) Proxmox сам предупреждает при создании: `WARN: Systemd 257 detected. You may need to enable nesting.` — без nesting контейнер тупит ещё и на уровне systemd.
+- **tun passthrough** через `lxc.cgroup2.devices.allow` и bind-mount `/dev/net`.
+
+Если изоляция контейнера критична (multi-tenant хост, privacy-sensitive workload) — берите KVM/QEMU-виртуалку с обычным инсталлятором вместо LXC.
+
+### Требования к LXC host
+
+**Proxmox LXC config** (`/etc/pve/lxc/<VMID>.conf`):
+
+```conf
+features: nesting=1
+lxc.cgroup2.devices.allow: c 10:200 rwm
+lxc.mount.entry: /dev/net dev/net none bind,create=dir
+```
+
+После правки config перезапустите контейнер: `pct stop <VMID> && pct start <VMID>`.
+
+**Forwarding внутри контейнера:**
+
+```bash
+echo 'net.ipv4.ip_forward=1' | sudo tee /etc/sysctl.d/99-awg-forwarding.conf
+sudo sysctl --system
+```
+
+### Установка amneziawg-go и amneziawg-tools
+
+**Вариант 1 (быстрее): prebuilt binary из релизов.** Скачиваем готовый бинарь, Go toolchain не нужен:
+
+```bash
+# Проверьте актуальную версию: https://github.com/amnezia-vpn/amneziawg-go/releases
+AWG_GO_VERSION="0.2.15"
+ARCH="amd64"  # или arm64 для ARM VPS
+sudo apt install -y iptables git make
+sudo curl -fsSL \
+  "https://github.com/amnezia-vpn/amneziawg-go/releases/download/v${AWG_GO_VERSION}/amneziawg-go-linux-${ARCH}" \
+  -o /usr/local/bin/amneziawg-go
+sudo chmod +x /usr/local/bin/amneziawg-go
+```
+
+**Вариант 2: сборка из source.** Нужен Go 1.21+. На Debian 12 системный `golang-go` — 1.19, поэтому либо ставьте из backports, либо скачайте Go вручную:
+
+```bash
+sudo apt install -y golang-go git make iptables
+git clone https://github.com/amnezia-vpn/amneziawg-go
+cd amneziawg-go && make && sudo make install
+cd ..
+```
+
+**amneziawg-tools** дают `awg` и `awg-quick` CLI. Системный `awg-quick` из `wireguard-tools` не понимает обфускационные параметры (`Jc/Jmin/Jmax/S1-S4/H1-H4/I1-I5`), поэтому именно этот форк нужен:
+
+```bash
+git clone https://github.com/amnezia-vpn/amneziawg-tools
+cd amneziawg-tools/src && make && sudo make install
+cd ../..
+```
+
+### Конфиг и запуск
+
+Создайте `/etc/amnezia/amneziawg/awg0.conf` — замените `YOUR_*` на свои значения. Ключи генерируются через `awg genkey | tee /etc/amnezia/amneziawg/server_private.key | awg pubkey`. Параметры обфускации (`Jc/Jmin/Jmax/S1-S4/H1-H4/I1`) должны совпадать с клиентом:
+
+```conf
+[Interface]
+Address = 10.9.9.1/24
+ListenPort = 39743
+PrivateKey = YOUR_SERVER_PRIVATE_KEY
+Jc = 4
+Jmin = 50
+Jmax = 150
+S1 = 0
+S2 = 0
+H1 = 1234567890
+H2 = 2345678901
+H3 = 3456789012
+H4 = 4012345678
+PostUp   = iptables -I INPUT   -p udp --dport 39743 -j ACCEPT
+PostUp   = iptables -I FORWARD -i eth0 -o awg0      -j ACCEPT
+PostUp   = iptables -I FORWARD -i awg0              -j ACCEPT
+PostUp   = iptables -t nat -A POSTROUTING -o eth0   -j MASQUERADE
+PostDown = iptables -D INPUT   -p udp --dport 39743 -j ACCEPT
+PostDown = iptables -D FORWARD -i eth0 -o awg0      -j ACCEPT
+PostDown = iptables -D FORWARD -i awg0              -j ACCEPT
+PostDown = iptables -t nat -D POSTROUTING -o eth0   -j MASQUERADE
+
+[Peer]
+PublicKey    = YOUR_CLIENT_PUBLIC_KEY
+PresharedKey = YOUR_PRESHARED_KEY
+AllowedIPs   = 10.9.9.2/32
+```
+
+Имя интерфейса (`awg0`) и внешний NIC (`eth0`) подставьте свои. Для IPv6 добавьте симметричные правила `ip6tables`. Порт `ListenPort` должен быть открыт на уровне хоста (UFW или iptables хоста) и на уровне облачного провайдера.
+
+Smoke-тест:
+
+```bash
+sudo awg-quick up awg0
+sudo awg                 # должен показать интерфейс и пиров
+sudo awg-quick down awg0
+```
+
+Запуск как systemd-сервис:
+
+```bash
+sudo systemctl enable awg-quick@awg0
+sudo systemctl start awg-quick@awg0
+sudo systemctl status awg-quick@awg0
+```
+
+### Работает ли `manage_amneziawg.sh` поверх?
+
+Мой `manage_amneziawg.sh` рассчитан на kernel-native setup (ждёт `/etc/amnezia/amneziawg/awgsetup_cfg.init`, полагается на `awg-quick` + `awg` из `amneziawg-tools`). Теоретически он должен работать поверх ручной установки `amneziawg-go` + `amneziawg-tools`, если интерфейс назван `awg0` и директория `/etc/amnezia/amneziawg/` существует. Этот сценарий я **не тестирую и не поддерживаю** — если нужен полноценный менеджмент клиентов, ведите конфиги руками или возьмите отдельный инструмент под userspace.
+
+### Источник
+
+Рабочий минимальный рецепт для Debian 13 в привилегированном LXC на Proxmox прислал [@Akh-commits](https://github.com/Akh-commits) в [issue #51](https://github.com/bivlked/amneziawg-installer/issues/51#issuecomment-4288953829) — этот раздел построен на нём с расширением по prebuilt-варианту, security-warning и нюансам Debian 12.
+
+---
+
 <a id="limitations-adv"></a>
 ## ⚠️ Известные ограничения
 
-* **LXC-контейнеры не поддерживаются.** AmneziaWG использует ядерный модуль (DKMS). LXC разделяет ядро с хостом — загрузить свой модуль из контейнера нельзя. Используйте полноценную VM или bare-metal сервер.
+* **LXC-контейнеры не поддерживаются моим инсталлятором.** AmneziaWG использует ядерный модуль (DKMS). LXC разделяет ядро с хостом — загрузить свой модуль из контейнера нельзя. Варианты: полноценная VM (KVM/QEMU) или bare-metal сервер для kernel-native установки, либо userspace-реализация `amneziawg-go` внутри LXC (см. [LXC / Docker через amneziawg-go](#lxc-userspace-adv)).
 
 * **Предполагается выделенный сервер.** Скрипт настраивает UFW, Fail2Ban, sysctl и оптимизирует систему под VPN. На сервере с другими сервисами используйте `--no-tweaks`, чтобы пропустить hardening.
 


### PR DESCRIPTION
## Summary

Adds a new ADVANCED.md / ADVANCED.en.md section documenting how to run `amneziawg-go` (userspace) inside a Proxmox LXC when the host cannot host the kernel module. Based on the working recipe shared by @Akh-commits in #51 (comment 4288953829) — explicit permission granted in [this comment](https://github.com/bivlked/amneziawg-installer/issues/51#issuecomment-4290460369).

## What's covered

- Security tradeoffs (privileged + nesting + tun passthrough; KVM recommended for isolation-critical use cases)
- Proxmox LXC host config (`features: nesting=1`, `lxc.cgroup2.devices.allow c 10:200 rwm`, `/dev/net` bind-mount) with the Proxmox 9 / systemd 257 nesting-required note @Akh-commits flagged
- Two install paths: prebuilt binary from `amneziawg-go` releases (no Go toolchain), or source build (Go 1.21+ nuance for Debian 12 system `golang-go` = 1.19)
- Full `awg0.conf` template with PostUp/PostDown iptables MASQUERADE rules
- Smoke test + systemd unit steps
- Honest disclaimer that `manage_amneziawg.sh` is not tested on top of a userspace setup

## Diff at a glance

- `ADVANCED.md`: +131 / -1 — TOC entry added; "LXC containers are not supported" bullet in Known Limitations now cross-refs the new section; new `<a id="lxc-userspace-adv">` section before Known Limitations
- `ADVANCED.en.md`: +131 / -1 — RU/EN parity preserved

## Checks

- 6 scripts `bash -n` clean (docs-only PR, no shell changes)
- New section passes lint for AI-patterns / plural-we / AI-tool-mentions
- Solo-dev voice applied throughout (`my installer`, `I maintain`, `I do not test`)
- Anchor consistency: `lxc-userspace-adv` appears 3x in each file (TOC + Limitations cross-ref + section anchor)

## Credit

Working recipe for privileged LXC Debian 13 on Proxmox 9 is from @Akh-commits. This PR generalizes it with the prebuilt path, security warning, and Debian 12 Go nuance; credit + back-link to his comment preserved in a dedicated "Источник / Source" subsection.

Closes #51 once merged.