### PR TITLE
docs(readme): add tested mobile carriers section (RU+EN)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -35,6 +35,7 @@
   <a href="#cli-vs-panel">CLI vs panels</a> •
   <a href="#quickstart">Quick Start</a> •
   <a href="#features">Features</a> •
+  <a href="#carriers">Carriers</a> •
   <a href="#requirements">Requirements</a> •
   <a href="#hosting-recommendation">Hosting</a> •
   <a href="#installation">Installation</a> •
@@ -143,6 +144,24 @@ All parameters are accepted automatically. Details: [ADVANCED.en.md#cli-params-a
 * Resume after reboot — the script picks up from where it left off
 * Choice of port, subnet, IPv6 mode, and routing mode. `--endpoint` flag for servers behind NAT
 </details>
+
+---
+
+<a id="carriers"></a>
+## 📡 Tested mobile carriers (Russia)
+
+If your VPN is unstable on mobile data, run the installer with `--preset=mobile`. Below — working configurations reported in issues and discussions:
+
+- **Yota** — Moscow, `--preset=mobile`
+- **Tele2** — Moscow (`--preset=mobile`); Krasnoyarsk (`--preset=mobile` + remove the `I1` parameter)
+- **Tattelecom / Letai** — Tatarstan, `--preset=mobile`
+- **Megafon** — regional networks, `--preset=mobile` + remove the `I1` parameter
+- **Beeline** — default preset, no flags needed
+- **Home / wired ISPs** — default preset usually works out of the box
+
+Your carrier is not on the list? Try `--preset=mobile`. If that doesn't work — open a thread in [Discussions](https://github.com/bivlked/amneziawg-installer/discussions) or [Issues](https://github.com/bivlked/amneziawg-installer/issues) and I'll add the entry.
+
+> Full operator parameter table (Jc, Jmin, Jmax, I1) — in [ADVANCED.en.md → FAQ "connects over cellular only on the third attempt"](ADVANCED.en.md#faq-advanced-adv). Per-flag overrides via `--jc`/`--jmin`/`--jmax` — in [ADVANCED.en.md → Presets](ADVANCED.en.md#presets-adv).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
   <a href="#cli-vs-panel">CLI vs панели</a> •
   <a href="#quickstart">Быстрый старт</a> •
   <a href="#vozmozhnosti">Что умеет</a> •
+  <a href="#operatory">Операторы</a> •
   <a href="#trebovaniya">Требования</a> •
   <a href="#recomend-hosting">Хостинг</a> •
   <a href="#ustanovka">Установка</a> •
@@ -143,6 +144,24 @@ sudo bash ./install_amneziawg.sh --yes --route-all
 * Возобновление установки после перезагрузки — скрипт продолжит с нужного шага
 * Выбор порта, подсети, режима IPv6 и маршрутизации. Поддержка `--endpoint` для серверов за NAT
 </details>
+
+---
+
+<a id="operatory"></a>
+## 📡 С какими операторами проверено
+
+Если VPN нестабилен через мобильный интернет, запускайте установку с `--preset=mobile`. Ниже — рабочие конфигурации по отчётам из issues и discussions:
+
+- **Yota** — Москва, `--preset=mobile`
+- **Tele2** — Москва (`--preset=mobile`); Красноярск (`--preset=mobile` + удалить параметр `I1`)
+- **Таттелеком / Летай** — Татарстан, `--preset=mobile`
+- **Мегафон** — регионы, `--preset=mobile` + удалить параметр `I1`
+- **Билайн** — дефолтный preset, флаги не нужны
+- **Домашний/проводной интернет** — дефолт, как правило, «из коробки»
+
+Вашего оператора нет в списке? Попробуйте `--preset=mobile`. Не помогло — заведите тред в [Discussions](https://github.com/bivlked/amneziawg-installer/discussions) или [Issues](https://github.com/bivlked/amneziawg-installer/issues), добавлю в список.
+
+> Полная таблица операторских параметров (Jc, Jmin, Jmax, I1) — в [ADVANCED.md → FAQ «через мобильную сеть»](ADVANCED.md#faq-advanced-adv). Точечная настройка через `--jc`/`--jmin`/`--jmax` — в [ADVANCED.md → Presets](ADVANCED.md#presets-adv).
 
 ---
 


### PR DESCRIPTION
## Summary

Surface 6 verified mobile-carrier entries (Yota, Tele2, Tattelecom/Letai, Megafon, Beeline, wired ISPs) on the README front page with a link to the full carrier table in ADVANCED.md. Bilingual: RU + EN.

Выношу 6 проверенных операторов на главную страницу README с ссылкой на полную таблицу параметров в ADVANCED.md. RU + EN.

## What changed

- `README.md` — new section anchor `#operatory` + nav entry «Операторы»
- `README.en.md` — new section anchor `#carriers` + nav entry «Carriers»
- +19 lines per file, between Features/Что умеет and Requirements/Требования
- No installer code touched

## Source

All entries come from the existing carrier table in ADVANCED.md (lines 674-685, FAQ-advanced section), originally built from issues and [Discussion #38](https://github.com/bivlked/amneziawg-installer/discussions/38).

## Test plan

- [ ] Render check on GitHub for both README files
- [ ] Nav links resolve to the new section anchors
- [ ] Inline links to `ADVANCED.md#faq-advanced-adv` and `#presets-adv` resolve
- [ ] No script/test changes — `bats` and `shellcheck` not required