### PR TITLE
v5.12.1: hotfix bundle for v5.12.0

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -14,6 +14,48 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [5.12.1] — 2026-05-08
+
+**v5.12.1** — patch release of the AmneziaWG 2.0 VPN installer: three small fixes for issues found in the first 48 hours after v5.12.0. No new features, no architectural changes. Support matrix unchanged: Ubuntu 24.04 / 25.10, Debian 12 / 13, x86_64 + ARM (Raspberry Pi, Oracle Ampere, Hetzner CAX).
+
+### Highlights
+
+- 🔧 **`AWG_SKIP_APPLY=1` works again in `manage add` / `manage remove`.** v5.12.0 added an unconditional pre-call to `ensure_amneziawg_kernel_module` before both actions to make `awg syncconf` reliable. Side effect: it broke the offline edit-only flow on dev / CI machines without the kernel module loaded, where `AWG_SKIP_APPLY=1` accumulates changes for batch apply (see [`ADVANCED.en.md`](ADVANCED.en.md) — environment variables section). The pre-call is now wrapped in `if [[ "${AWG_SKIP_APPLY:-0}" != "1" ]]`. `manage restart` is intentionally NOT gated — it is an explicit apply, AWG_SKIP_APPLY has no meaningful semantics for it. Only the literal `1` is honoured; `yes`, `true`, any other string — same behaviour as unset (apply happens).
+- ☁ **`linux-headers-cloud-${arch}` in the repair-module fallback on Debian.** `awg_common.sh:_install_kernel_headers` (used by `manage repair-module`) on Debian only tried `linux-headers-${kernel_ver}` and `linux-headers-${arch}`. On AWS / Azure / GCP / cloud-Hetzner (kernel name contains `-cloud-`) the exact-version package can disappear from the mirror after a kernel upgrade, while the cloud meta `linux-headers-cloud-${arch}` stays available. The installer's step 2 already knew about cloud-headers via smart detection; now `repair-module` knows too and tries the cloud meta before the generic one. Standard kernels (no `-cloud-` in the name) — behaviour unchanged.
+- 📦 **ARM prebuilt packages now decompress correctly with the in-tree kernel decoder** ([Issue #76](https://github.com/bivlked/amneziawg-installer/issues/76)). `scripts/build-arm-deb.sh` used `xz -9` (CRC64 check, 64 MiB dictionary) — the userspace `xz -t` tool considered the stream valid, but the in-tree Linux decoder on Debian 13 trixie kernel `6.12.85+deb13-arm64` (build 2026-04-30) returned `decompression failed with status 6`. Switched to a kernel-compatible preset `xz --check=crc32 --lzma2=dict=1MiB` — matches mainline `scripts/Makefile.modinst`. Plus a build-time sanity gate: after compression, `xz -t` + `xz -d -c` round-trip; if anything fails — `exit 1`, no broken prebuilt ships to the `arm-packages` release. On the v5.12.1 tag push, CI workflow `arm-build.yml` re-publishes all 14 ARM prebuilt packages with the new xz flags.
+
+### Install
+
+```bash
+wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg_en.sh
+chmod +x install_amneziawg_en.sh
+sudo bash ./install_amneziawg_en.sh
+```
+
+3 commands → ~20 minutes → a ready-to-use VPN server with traffic obfuscation. Details — [README → Install](README.en.md#install).
+
+### Upgrading an existing server
+
+Run a fresh `install_amneziawg_en.sh` — at step 5, `manage_amneziawg.sh` and `awg_common.sh` are updated automatically (with SHA256 verification). Full commands — [ADVANCED.en.md → How to update the scripts](ADVANCED.en.md#-how-to-update-the-scripts).
+
+### Tests
+
+**+30 new bats tests** (387 in the matrix, was 357 in v5.12.0):
+
+- `test_v5121_skip_apply_regression.bats` (+14) — RU/EN structural greps on `add` / `remove` / `restart` blocks, plus runtime semantics of the gate for every documented value (unset / 0 / 1 / yes / true / YES); confirms `repair-module` keeps the `AWG_ALLOW_APT_IN_ENSURE=1 ensure_amneziawg_kernel_module full` invocation; bash -n syntax sanity.
+- `test_v5121_cloud_headers.bats` (+9) — functional test of `_install_kernel_headers` via mocked `apt-get` and `dpkg`: cloud kernel gets the cloud meta in candidates before the generic one, standard kernel does not, Ubuntu codepath untouched; the EN mirror `awg_common_en.sh` is verified separately.
+- `test_v5121_xz_kernel_compat.bats` (+7) — structural greps for the new xz flags in `build-arm-deb.sh`, fail-fast on sanity-stage failure, local round-trip with the same flags (toolchain smoke test; kernel-decompressor compatibility itself is best validated on a real kernel boot — VPS or QEMU with the target kernel).
+- `test_v5115_regen_multiarg.bats` — version assertion bumped from 5.12.0 to 5.12.1.
+
+### Compatibility and dependencies
+
+- **Fully backwards-compatible.** All three fixes change behaviour only in narrow regression cases (offline edit / cloud-kernel repair / ARM prebuilt on Debian 13 trixie). The standard install + client flow is unchanged.
+- **No new dependencies.**
+
+[Full diff against v5.12.0](https://github.com/bivlked/amneziawg-installer/compare/v5.12.0...v5.12.1)
+
+---
+
 ## [5.12.0] — 2026-05-06
 
 **v5.12.0** — feature release of the AmneziaWG 2.0 VPN installer: one big feature — **automatic DKMS module recovery on kernel upgrade**. No architectural changes: compatible with all v5.11.x installs — the apt hook, systemd unit, and helper are deployed on the next run of `install_amneziawg_en.sh`. Support matrix unchanged: Ubuntu 24.04 / 25.10, Debian 12 / 13, x86_64 + ARM (Raspberry Pi, Oracle Ampere, Hetzner CAX).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,48 @@
 
 ---
 
+## [5.12.1] — 2026-05-08
+
+**v5.12.1** — патч-релиз AmneziaWG 2.0 VPN-инсталлятора: три точечных исправления, найденных в первые 48 часов после v5.12.0. Без новых фич, без архитектурных сдвигов. Поддержка Ubuntu 24.04 / 25.10, Debian 12 / 13, x86_64 + ARM (Raspberry Pi, Oracle Ampere, Hetzner CAX) — без изменений.
+
+### Главное
+
+- 🔧 **`AWG_SKIP_APPLY=1` снова работает в `manage add` / `manage remove`.** В v5.12.0 я добавил безусловный pre-call `ensure_amneziawg_kernel_module` перед обоими действиями для надёжного syncconf. Побочно это сломало offline edit-only flow на dev/CI-машинах без загруженного kernel-модуля, где `AWG_SKIP_APPLY=1` накапливает изменения для batch-применения (см. [`ADVANCED.md`](ADVANCED.md) — раздел про переменные среды). Теперь pre-call обёрнут в `if [[ "${AWG_SKIP_APPLY:-0}" != "1" ]]`. `manage restart` остаётся без gate'а — это явный apply, для него AWG_SKIP_APPLY бессмыслен. Распознаётся только литерал `1`; `yes`, `true`, любая другая строка — поведение как при unset (apply делается).
+- ☁ **`linux-headers-cloud-${arch}` в repair-module fallback на Debian.** `awg_common.sh:_install_kernel_headers` (используется `manage repair-module`) на Debian пробовал только `linux-headers-${kernel_ver}` и `linux-headers-${arch}`. На AWS / Azure / GCP / cloud-Hetzner (kernel name содержит `-cloud-`) точная-версия пакета может пропасть из репо после kernel upgrade, а cloud-meta `linux-headers-cloud-${arch}` остаётся доступным. Шаг 2 установки уже умел cloud-headers через smart detection в installer'е; теперь и repair-module знает про cloud-meta и пробует его раньше generic. Standard-ядра (без `-cloud-` в имени) — поведение не меняется.
+- 📦 **ARM prebuilt-пакеты теперь корректно декомпрессируются ядерным декодером** ([Issue #76](https://github.com/bivlked/amneziawg-installer/issues/76)). `scripts/build-arm-deb.sh` использовал `xz -9` (CRC64-проверка, 64 MiB словарь) — userspace `xz -t` стрим валидным считал, но in-tree decoder Linux на Debian 13 trixie kernel `6.12.85+deb13-arm64` (build 2026-04-30) отвечал `decompression failed with status 6`. Свитчнул на kernel-compatible preset `xz --check=crc32 --lzma2=dict=1MiB` — соответствует mainline `scripts/Makefile.modinst`. Plus build-time sanity gate: после компрессии `xz -t` + `xz -d -c` round-trip; если что-то не так — `exit 1`, broken prebuilt не попадает в `arm-packages` release. На push'е тега v5.12.1 CI workflow `arm-build.yml` перепубликует все 14 ARM prebuilt-пакетов с новыми xz-флагами.
+
+### Установка
+
+```bash
+wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg.sh
+chmod +x install_amneziawg.sh
+sudo bash ./install_amneziawg.sh
+```
+
+3 команды → ~20 минут → готовый VPN-сервер с обфускацией трафика. Подробнее — [README → Установка](README.md#установка).
+
+### Обновление существующего сервера
+
+Запустите `install_amneziawg.sh` свежей версии — на 5-м шаге `manage_amneziawg.sh` и `awg_common.sh` обновятся автоматически (с проверкой SHA256). Полные команды — [ADVANCED.md → Как обновить скрипты](ADVANCED.md#-как-обновить-скрипты).
+
+### Тесты
+
+**+30 новых bats** (387 в матрице, было 357 на v5.12.0):
+
+- `test_v5121_skip_apply_regression.bats` (+14) — RU/EN structural greps на `add` / `remove` / `restart` блоки, plus runtime semantics gate'а для всех документированных значений (unset / 0 / 1 / yes / true / YES); проверка что `repair-module` сохраняет `AWG_ALLOW_APT_IN_ENSURE=1 ensure_amneziawg_kernel_module full`; bash -n syntax sanity.
+- `test_v5121_cloud_headers.bats` (+9) — функциональный тест `_install_kernel_headers` через mock'и `apt-get` и `dpkg`: cloud-kernel получает cloud-meta в кандидатах раньше generic, standard-kernel — не получает, Ubuntu codepath не задет; EN-mirror `awg_common_en.sh` проверен отдельно.
+- `test_v5121_xz_kernel_compat.bats` (+7) — структурные greps на новые xz-флаги в `build-arm-deb.sh`, fail-fast при сбое sanity-стадии, локальный round-trip с теми же флагами (toolchain smoke; kernel-decompressor compatibility лучше всего проверяется реальной kernel-загрузкой — VPS или QEMU с целевым ядром).
+- `test_v5115_regen_multiarg.bats` — bumped version assertion с 5.12.0 до 5.12.1.
+
+### Совместимость и зависимости
+
+- **Полностью обратно-совместимо.** Все три фикса меняют поведение только в редких регрессивных кейсах (offline edit / cloud-kernel repair / ARM prebuilt на Debian 13 trixie). Штатный сценарий установки и работы клиентов — без изменений.
+- **Новых зависимостей нет.**
+
+[Полный список изменений с момента v5.12.0](https://github.com/bivlked/amneziawg-installer/compare/v5.12.0...v5.12.1)
+
+---
+
 ## [5.12.0] — 2026-05-06
 
 **v5.12.0** — feature-релиз AmneziaWG 2.0 VPN-инсталлятора: одна большая фича — **автоматическое восстановление DKMS-модуля при обновлении ядра**. Без архитектурных изменений: совместимо со всеми установками v5.11.x — apt hook, systemd unit и helper доустанавливаются при следующем запуске `install_amneziawg.sh`. Поддержка Ubuntu 24.04 / 25.10, Debian 12 / 13, x86_64 + ARM (Raspberry Pi, Oracle Ampere, Hetzner CAX) — без изменений.

--- a/README.en.md
+++ b/README.en.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/Architecture-x86__64_|_ARM64_|_ARMv7-green" alt="x86_64 | ARM64 | ARMv7">
   <a href="https://github.com/bivlked/amneziawg-installer/blob/main/LICENSE"><img src="https://img.shields.io/github/license/bivlked/amneziawg-installer" alt="License"></a>
   <img src="https://img.shields.io/badge/Status-Stable-success" alt="Status">
-  <a href="https://github.com/bivlked/amneziawg-installer/releases"><img src="https://img.shields.io/badge/Installer_Version-5.12.0-blue" alt="Version"></a>
+  <a href="https://github.com/bivlked/amneziawg-installer/releases"><img src="https://img.shields.io/badge/Installer_Version-5.12.1-blue" alt="Version"></a>
   <img src="https://img.shields.io/badge/AmneziaWG-2.0-blueviolet" alt="AWG 2.0">
   <a href="https://github.com/bivlked/amneziawg-installer/actions/workflows/shellcheck.yml"><img src="https://github.com/bivlked/amneziawg-installer/actions/workflows/shellcheck.yml/badge.svg" alt="ShellCheck"></a>
   <a href="https://github.com/bivlked/amneziawg-installer/actions/workflows/test.yml"><img src="https://github.com/bivlked/amneziawg-installer/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
@@ -100,7 +100,7 @@ Works on Ubuntu 24.04/25.10 and Debian 12/13. Any cheap VPS with 1 GB RAM is eno
 ## 🚀 Quick Start
 
 ```bash
-wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.0/install_amneziawg_en.sh
+wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg_en.sh
 chmod +x install_amneziawg_en.sh
 sudo bash ./install_amneziawg_en.sh
 ```
@@ -231,8 +231,8 @@ This installation method ensures correct handling of interactive prompts and col
 
 2.  **Download the script:**
     ```bash
-    wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.0/install_amneziawg_en.sh
-    # or: curl -fLo install_amneziawg_en.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.0/install_amneziawg_en.sh
+    wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg_en.sh
+    # or: curl -fLo install_amneziawg_en.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg_en.sh
     ```
 3.  **Make it executable:**
     ```bash
@@ -246,7 +246,7 @@ This installation method ensures correct handling of interactive prompts and col
 
     > **Russian version:** For Russian output, use `install_amneziawg.sh`:
     > ```bash
-    > wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.0/install_amneziawg.sh
+    > wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg.sh
     > sudo bash ./install_amneziawg.sh
     > ```
     > The Russian version is functionally identical; only user-facing messages and logs are in Russian.
@@ -357,11 +357,11 @@ sudo bash /root/awg/manage_amneziawg.sh <command> [arguments]
 
 ```bash
 # Installation (English)
-wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.0/install_amneziawg_en.sh
+wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg_en.sh
 sudo bash ./install_amneziawg_en.sh       # Run (+ 2 reboots)
 
 # Installation (Russian)
-wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.0/install_amneziawg.sh
+wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg.sh
 sudo bash ./install_amneziawg.sh          # Run (+ 2 reboots)
 
 # Client management
@@ -428,13 +428,13 @@ For the changelog, see **[CHANGELOG.en.md](CHANGELOG.en.md)**.
   <b>A:</b> Download the updated scripts and replace them on the server:
   <pre>
   # English version:
-  wget -O /root/awg/manage_amneziawg.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.0/manage_amneziawg_en.sh
-  wget -O /root/awg/awg_common.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.0/awg_common_en.sh
+  wget -O /root/awg/manage_amneziawg.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/manage_amneziawg_en.sh
+  wget -O /root/awg/awg_common.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/awg_common_en.sh
   chmod 700 /root/awg/manage_amneziawg.sh /root/awg/awg_common.sh
 
   # Russian version:
-  wget -O /root/awg/manage_amneziawg.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.0/manage_amneziawg.sh
-  wget -O /root/awg/awg_common.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.0/awg_common.sh
+  wget -O /root/awg/manage_amneziawg.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/manage_amneziawg.sh
+  wget -O /root/awg/awg_common.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/awg_common.sh
   chmod 700 /root/awg/manage_amneziawg.sh /root/awg/awg_common.sh
   </pre>
   Server reinstallation is not required.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/Architecture-x86__64_|_ARM64_|_ARMv7-green" alt="x86_64 | ARM64 | ARMv7">
   <a href="https://github.com/bivlked/amneziawg-installer/blob/main/LICENSE"><img src="https://img.shields.io/github/license/bivlked/amneziawg-installer" alt="License"></a>
   <img src="https://img.shields.io/badge/Status-Stable-success" alt="Status">
-  <a href="https://github.com/bivlked/amneziawg-installer/releases"><img src="https://img.shields.io/badge/Installer_Version-5.12.0-blue" alt="Version"></a>
+  <a href="https://github.com/bivlked/amneziawg-installer/releases"><img src="https://img.shields.io/badge/Installer_Version-5.12.1-blue" alt="Version"></a>
   <img src="https://img.shields.io/badge/AmneziaWG-2.0-blueviolet" alt="AWG 2.0">
   <a href="https://github.com/bivlked/amneziawg-installer/actions/workflows/shellcheck.yml"><img src="https://github.com/bivlked/amneziawg-installer/actions/workflows/shellcheck.yml/badge.svg" alt="ShellCheck"></a>
   <a href="https://github.com/bivlked/amneziawg-installer/actions/workflows/test.yml"><img src="https://github.com/bivlked/amneziawg-installer/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
@@ -100,7 +100,7 @@
 ## 🚀 Быстрый старт
 
 ```bash
-wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.0/install_amneziawg.sh
+wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg.sh
 chmod +x install_amneziawg.sh
 sudo bash ./install_amneziawg.sh
 ```
@@ -231,8 +231,8 @@ sudo bash ./install_amneziawg.sh --yes --route-all
 
 2.  **Скачайте скрипт:**
     ```bash
-    wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.0/install_amneziawg.sh
-    # или: curl -fLo install_amneziawg.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.0/install_amneziawg.sh
+    wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg.sh
+    # или: curl -fLo install_amneziawg.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg.sh
     ```
 3.  **Сделайте его исполняемым:**
     ```bash
@@ -246,7 +246,7 @@ sudo bash ./install_amneziawg.sh --yes --route-all
 
     > **English version:** Для вывода на английском используйте `install_amneziawg_en.sh`:
     > ```bash
-    > wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.0/install_amneziawg_en.sh
+    > wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg_en.sh
     > sudo bash ./install_amneziawg_en.sh
     > ```
     > Английская версия функционально идентична; только сообщения и логи на английском.
@@ -357,11 +357,11 @@ sudo bash /root/awg/manage_amneziawg.sh <команда> [аргументы]
 
 ```bash
 # Установка (русский)
-wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.0/install_amneziawg.sh
+wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg.sh
 sudo bash ./install_amneziawg.sh          # Запуск (+ 2 перезагрузки)
 
 # Установка (English)
-wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.0/install_amneziawg_en.sh
+wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg_en.sh
 sudo bash ./install_amneziawg_en.sh       # Запуск (+ 2 перезагрузки)
 
 # Управление клиентами
@@ -428,13 +428,13 @@ sudo bash /root/awg/manage_amneziawg.sh restart              # Перезапу�
   <b>О:</b> Скачайте новый скрипт установки и замените скрипты управления на сервере:
   <pre>
   # Русская версия:
-  wget -O /root/awg/manage_amneziawg.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.0/manage_amneziawg.sh
-  wget -O /root/awg/awg_common.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.0/awg_common.sh
+  wget -O /root/awg/manage_amneziawg.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/manage_amneziawg.sh
+  wget -O /root/awg/awg_common.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/awg_common.sh
   chmod 700 /root/awg/manage_amneziawg.sh /root/awg/awg_common.sh
 
   # Английская версия:
-  wget -O /root/awg/manage_amneziawg.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.0/manage_amneziawg_en.sh
-  wget -O /root/awg/awg_common.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.0/awg_common_en.sh
+  wget -O /root/awg/manage_amneziawg.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/manage_amneziawg_en.sh
+  wget -O /root/awg/awg_common.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/awg_common_en.sh
   chmod 700 /root/awg/manage_amneziawg.sh /root/awg/awg_common.sh
   </pre>
   Переустановка сервера не требуется.

--- a/awg_common.sh
+++ b/awg_common.sh
@@ -3,8 +3,8 @@
 # ==============================================================================
 # Общая библиотека функций для AmneziaWG 2.0
 # Автор: @bivlked
-# Версия: 5.12.0
-# Дата: 2026-05-06
+# Версия: 5.12.1
+# Дата: 2026-05-08
 # Репозиторий: https://github.com/bivlked/amneziawg-installer
 # ==============================================================================
 #
@@ -270,7 +270,18 @@ _install_kernel_headers() {
             local arch
             arch=$(dpkg --print-architecture 2>/dev/null)
             candidates+=("linux-headers-${kernel_ver}")
-            [[ -n "$arch" ]] && candidates+=("linux-headers-${arch}")
+            if [[ -n "$arch" ]]; then
+                # Cloud-images Debian используют отдельный мета-пакет
+                # linux-headers-cloud-${arch} вместо обычного linux-headers-${arch}
+                # (kernel ABI в них другая — sched/IRQ-таймеры урезаны под VM).
+                # Prefer cloud-meta когда running kernel явно cloud — иначе
+                # repair-module падает на AWS/Azure/GCP/cloud-Hetzner после
+                # kernel upgrade, хотя headers доступны через cloud-meta.
+                if [[ "$kernel_ver" == *-cloud-* ]]; then
+                    candidates+=("linux-headers-cloud-${arch}")
+                fi
+                candidates+=("linux-headers-${arch}")
+            fi
             ;;
         *)
             log_error "Установка kernel headers: неизвестный OS_ID='${OS_ID:-}' (поддерживаются только ubuntu/debian)."

--- a/awg_common_en.sh
+++ b/awg_common_en.sh
@@ -3,8 +3,8 @@
 # ==============================================================================
 # Shared function library for AmneziaWG 2.0
 # Author: @bivlked
-# Version: 5.12.0
-# Date: 2026-05-06
+# Version: 5.12.1
+# Date: 2026-05-08
 # Repository: https://github.com/bivlked/amneziawg-installer
 # ==============================================================================
 #
@@ -271,7 +271,20 @@ _install_kernel_headers() {
             local arch
             arch=$(dpkg --print-architecture 2>/dev/null)
             candidates+=("linux-headers-${kernel_ver}")
-            [[ -n "$arch" ]] && candidates+=("linux-headers-${arch}")
+            if [[ -n "$arch" ]]; then
+                # Debian cloud images use a dedicated meta-package
+                # linux-headers-cloud-${arch} instead of the generic
+                # linux-headers-${arch} (different kernel ABI — sched/IRQ
+                # timers trimmed for VMs). Prefer cloud-meta when the
+                # running kernel is explicitly a cloud build — otherwise
+                # repair-module fails on AWS/Azure/GCP/cloud-Hetzner after
+                # a kernel upgrade, even though headers are available via
+                # the cloud meta-package.
+                if [[ "$kernel_ver" == *-cloud-* ]]; then
+                    candidates+=("linux-headers-cloud-${arch}")
+                fi
+                candidates+=("linux-headers-${arch}")
+            fi
             ;;
         *)
             log_error "Installing kernel headers: unknown OS_ID='${OS_ID:-}' (only ubuntu/debian are supported)."

--- a/install_amneziawg.sh
+++ b/install_amneziawg.sh
@@ -8,15 +8,15 @@ fi
 # ==============================================================================
 # Скрипт для установки и настройки AmneziaWG 2.0 на Ubuntu/Debian серверах
 # Автор: @bivlked
-# Версия: 5.12.0
-# Дата: 2026-05-06
+# Версия: 5.12.1
+# Дата: 2026-05-08
 # Репозиторий: https://github.com/bivlked/amneziawg-installer
 # ==============================================================================
 
 # --- Безопасный режим и Константы ---
 set -o pipefail
 
-SCRIPT_VERSION="5.12.0"
+SCRIPT_VERSION="5.12.1"
 AWG_DIR="/root/awg"
 CONFIG_FILE="$AWG_DIR/awgsetup_cfg.init"
 STATE_FILE="$AWG_DIR/setup_state"
@@ -33,8 +33,8 @@ MANAGE_SCRIPT_PATH="$AWG_DIR/manage_amneziawg.sh"
 # Проверяются в step5_download_scripts() после curl.
 # Если AWG_BRANCH переопределён (не v$SCRIPT_VERSION), проверка пропускается.
 # Формат: sha256sum output (hex, 64 chars).
-COMMON_SCRIPT_SHA256="9cd66802db78dcfd0e05cb2e4f4abaae4469e75f568bb33aa8f11d8bb8960429"
-MANAGE_SCRIPT_SHA256="275ecc9fdde96fbbf08ead2dc2e98d0e13816fce0be6a6fbed8c13505e6a07fd"
+COMMON_SCRIPT_SHA256="2f75bb5c827f7e3d36ecbb716b0b89096591694c1a636c31c784683738140eb9"
+MANAGE_SCRIPT_SHA256="59958e56a8d8d611c7f88438883b2662fff87c17cf103324916bf8d482c6fb02"
 
 # Флаги CLI
 UNINSTALL=0; HELP=0; DIAGNOSTIC=0; VERBOSE=0; NO_COLOR=0; AUTO_YES=0; NO_TWEAKS=0

--- a/install_amneziawg_en.sh
+++ b/install_amneziawg_en.sh
@@ -8,14 +8,14 @@ fi
 # ==============================================================================
 # AmneziaWG 2.0 installation and configuration script for Ubuntu/Debian servers
 # Author: @bivlked
-# Version: 5.12.0
-# Date: 2026-05-06
+# Version: 5.12.1
+# Date: 2026-05-08
 # Repository: https://github.com/bivlked/amneziawg-installer
 # ==============================================================================
 
 # --- Safe mode and Constants ---
 set -o pipefail
-SCRIPT_VERSION="5.12.0"
+SCRIPT_VERSION="5.12.1"
 
 AWG_DIR="/root/awg"
 CONFIG_FILE="$AWG_DIR/awgsetup_cfg.init"
@@ -33,8 +33,8 @@ MANAGE_SCRIPT_PATH="$AWG_DIR/manage_amneziawg.sh"
 # Verified in step5_download_scripts() after curl.
 # Verification is skipped when AWG_BRANCH is overridden (test branch).
 # Format: sha256sum output (hex, 64 chars).
-COMMON_SCRIPT_SHA256="526367064c7f8cee919b5b407a80d3c8de45d47e04cbed68f0f15ac3f4f78ef5"
-MANAGE_SCRIPT_SHA256="484ad9e266981b52969aac7774f5afacc37c374c590a26ebe6852467415cf470"
+COMMON_SCRIPT_SHA256="a788844e9097b373ed5a8cf1ea0e00965a8ccd1e187b607809a2dfe550ae1e62"
+MANAGE_SCRIPT_SHA256="24f64630a0384b8660e4587d8776309f0bb32db8be4281a5dedda0718f54f5f4"
 
 # CLI flags
 UNINSTALL=0; HELP=0; DIAGNOSTIC=0; VERBOSE=0; NO_COLOR=0; AUTO_YES=0; NO_TWEAKS=0

--- a/manage_amneziawg.sh
+++ b/manage_amneziawg.sh
@@ -8,14 +8,14 @@ fi
 # ==============================================================================
 # Скрипт для управления пользователями (пирами) AmneziaWG 2.0
 # Автор: @bivlked
-# Версия: 5.12.0
-# Дата: 2026-05-06
+# Версия: 5.12.1
+# Дата: 2026-05-08
 # Репозиторий: https://github.com/bivlked/amneziawg-installer
 # ==============================================================================
 
 # --- Безопасный режим и Константы ---
 # shellcheck disable=SC2034
-SCRIPT_VERSION="5.12.0"
+SCRIPT_VERSION="5.12.1"
 set -o pipefail
 AWG_DIR="/root/awg"
 SERVER_CONF_FILE="/etc/amnezia/amneziawg/awg0.conf"
@@ -1150,8 +1150,12 @@ case $COMMAND in
 
         # Гарантируем, что модуль ядра amneziawg загружен и awg-quick@awg0 активен.
         # Без этого apply_config (awg syncconf) упадёт. См. также 'manage repair-module'.
-        ensure_amneziawg_kernel_module \
-            || die "Модуль ядра amneziawg недоступен. Запустите 'manage repair-module' и повторите."
+        # AWG_SKIP_APPLY=1 (offline/batch edit без apply): пропускаем проверку модуля —
+        # apply_config сам сделает no-op, и команда должна работать на dev-машине.
+        if [[ "${AWG_SKIP_APPLY:-0}" != "1" ]]; then
+            ensure_amneziawg_kernel_module \
+                || die "Модуль ядра amneziawg недоступен. Запустите 'manage repair-module' и повторите."
+        fi
 
         # --psk: включить опциональный PresharedKey для каждого нового клиента.
         # Export CLIENT_PSK="auto" → generate_client сам сгенерирует 32-байт
@@ -1239,8 +1243,12 @@ case $COMMAND in
             fi
 
             # Гарантируем загруженный модуль до любых мутаций (apply_config / awg syncconf).
-            ensure_amneziawg_kernel_module \
-                || die "Модуль ядра amneziawg недоступен. Запустите 'manage repair-module' и повторите."
+            # AWG_SKIP_APPLY=1 (offline/batch edit без apply): пропускаем проверку модуля —
+            # apply_config сам сделает no-op, и команда должна работать на dev-машине.
+            if [[ "${AWG_SKIP_APPLY:-0}" != "1" ]]; then
+                ensure_amneziawg_kernel_module \
+                    || die "Модуль ядра amneziawg недоступен. Запустите 'manage repair-module' и повторите."
+            fi
 
             _removed=0
             for _rname in "${_valid_names[@]}"; do

--- a/manage_amneziawg_en.sh
+++ b/manage_amneziawg_en.sh
@@ -8,14 +8,14 @@ fi
 # ==============================================================================
 # AmneziaWG 2.0 peer management script
 # Author: @bivlked
-# Version: 5.12.0
-# Date: 2026-05-06
+# Version: 5.12.1
+# Date: 2026-05-08
 # Repository: https://github.com/bivlked/amneziawg-installer
 # ==============================================================================
 
 # --- Safe mode and Constants ---
 # shellcheck disable=SC2034
-SCRIPT_VERSION="5.12.0"
+SCRIPT_VERSION="5.12.1"
 set -o pipefail
 AWG_DIR="/root/awg"
 SERVER_CONF_FILE="/etc/amnezia/amneziawg/awg0.conf"
@@ -1153,8 +1153,12 @@ case $COMMAND in
 
         # Make sure the amneziawg kernel module is loaded and awg-quick@awg0 is up.
         # Without it apply_config (awg syncconf) fails. See also 'manage repair-module'.
-        ensure_amneziawg_kernel_module \
-            || die "amneziawg kernel module unavailable. Run 'manage repair-module' and try again."
+        # AWG_SKIP_APPLY=1 (offline/batch edit without apply): skip the module check —
+        # apply_config will no-op anyway, and the command must work on a dev machine.
+        if [[ "${AWG_SKIP_APPLY:-0}" != "1" ]]; then
+            ensure_amneziawg_kernel_module \
+                || die "amneziawg kernel module unavailable. Run 'manage repair-module' and try again."
+        fi
 
         # --psk: enable optional PresharedKey for every new client.
         # Export CLIENT_PSK="auto" -> generate_client produces a fresh
@@ -1241,8 +1245,12 @@ case $COMMAND in
             fi
 
             # Ensure module is loaded before any mutations (apply_config / awg syncconf).
-            ensure_amneziawg_kernel_module \
-                || die "amneziawg kernel module unavailable. Run 'manage repair-module' and try again."
+            # AWG_SKIP_APPLY=1 (offline/batch edit without apply): skip the module check —
+            # apply_config will no-op anyway, and the command must work on a dev machine.
+            if [[ "${AWG_SKIP_APPLY:-0}" != "1" ]]; then
+                ensure_amneziawg_kernel_module \
+                    || die "amneziawg kernel module unavailable. Run 'manage repair-module' and try again."
+            fi
 
             _removed=0
             for _rname in "${_valid_names[@]}"; do

--- a/scripts/build-arm-deb.sh
+++ b/scripts/build-arm-deb.sh
@@ -104,8 +104,25 @@ MODULE_INSTALL_PATH="${DEB_DIR}/lib/modules/${KERNEL_VERSION}/extra"
 mkdir -p "$MODULE_INSTALL_PATH" "${DEB_DIR}/DEBIAN"
 
 cp "$KO_PATH" "$MODULE_INSTALL_PATH/amneziawg.ko"
-if xz -9 "$MODULE_INSTALL_PATH/amneziawg.ko" 2>/dev/null; then
-    echo "Module compressed with xz"
+# xz options chosen to match upstream kernel scripts/Makefile.modinst:
+#   --check=crc32  : in-tree decompressor expects crc32, not the xz-default crc64.
+#   --lzma2=dict=1MiB : 1 MiB dictionary fits in-tree decoder memory budget on
+#                       all supported targets. xz -9 (default 64 MiB) decodes
+#                       fine in userspace via `xz -d` but kernel decompressor
+#                       on Debian 13 trixie 6.12.85-1 returns "decompression
+#                       failed with status 6" (Issue #76). Reverting to the
+#                       conservative preset is the documented fix.
+KO_FILE="$MODULE_INSTALL_PATH/amneziawg.ko"
+if xz --check=crc32 --lzma2=dict=1MiB -f "$KO_FILE" 2>/dev/null; then
+    KO_XZ="${KO_FILE}.xz"
+    # Sanity: kernel-compatible streams round-trip through `xz -d` and `xz -t`.
+    # Catches preset/filter mismatches at build time instead of in users' dmesg.
+    if xz -t "$KO_XZ" 2>/dev/null && xz -d -c "$KO_XZ" >/dev/null 2>&1; then
+        echo "Module compressed with xz (crc32, 1 MiB dict, sanity OK)"
+    else
+        echo "ERROR: xz sanity check failed for $KO_XZ — refusing to ship a broken prebuilt." >&2
+        exit 1
+    fi
 else
     echo "xz compression skipped — packaging uncompressed .ko"
 fi

--- a/tests/test_v5115_regen_multiarg.bats
+++ b/tests/test_v5115_regen_multiarg.bats
@@ -113,13 +113,13 @@
 
 # ---------- Version markers ----------
 
-@test "v5.12.0: SCRIPT_VERSION bumped in all six files" {
+@test "v5.12.1: SCRIPT_VERSION bumped in all six files" {
     for f in install_amneziawg.sh install_amneziawg_en.sh manage_amneziawg.sh manage_amneziawg_en.sh; do
-        run grep -E 'SCRIPT_VERSION="5\.12\.0"' "$BATS_TEST_DIRNAME/../$f"
+        run grep -E 'SCRIPT_VERSION="5\.12\.1"' "$BATS_TEST_DIRNAME/../$f"
         [ "$status" -eq 0 ]
     done
-    run grep -E '# Версия: 5\.12\.0' "$BATS_TEST_DIRNAME/../awg_common.sh"
+    run grep -E '# Версия: 5\.12\.1' "$BATS_TEST_DIRNAME/../awg_common.sh"
     [ "$status" -eq 0 ]
-    run grep -E '# Version: 5\.12\.0' "$BATS_TEST_DIRNAME/../awg_common_en.sh"
+    run grep -E '# Version: 5\.12\.1' "$BATS_TEST_DIRNAME/../awg_common_en.sh"
     [ "$status" -eq 0 ]
 }

--- a/tests/test_v5121_cloud_headers.bats
+++ b/tests/test_v5121_cloud_headers.bats
@@ -1,0 +1,175 @@
+#!/usr/bin/env bats
+# v5.12.1 cloud-headers fallback in awg_common._install_kernel_headers().
+#
+# Background: installer's step 2 has smart kernel-headers detection that
+# already picks linux-headers-cloud-${arch} on Debian cloud kernels. The
+# repair-module path uses the shared awg_common.sh helper, which previously
+# only tried linux-headers-${kernel_ver} and linux-headers-${arch}.
+# When the exact-version package vanishes from the mirror after a kernel
+# upgrade — common on AWS/Azure/GCP/cloud-Hetzner — repair-module fell
+# through, even though linux-headers-cloud-${arch} was available.
+#
+# Fix: when the running kernel is a Debian cloud build (`*-cloud-*`),
+# add linux-headers-cloud-${arch} into the candidate list before the
+# generic linux-headers-${arch}.
+
+load test_helper
+
+setup() {
+    TEST_DIR=$(mktemp -d)
+    export AWG_DIR="$TEST_DIR"
+    export MOCK_BIN="$TEST_DIR/mock_bin"
+    mkdir -p "$MOCK_BIN"
+    export PATH="$MOCK_BIN:$PATH"
+
+    # Silent log stubs for clean test output.
+    log()       { :; }
+    log_warn()  { :; }
+    log_error() { :; }
+    log_debug() { :; }
+    export -f log log_warn log_error log_debug
+
+    # Mock apt-get: always fail to install, but record each requested pkg
+    # in CALLS_LOG. This lets us assert the candidate order without needing
+    # any real apt repository.
+    cat > "$MOCK_BIN/apt-get" << 'STUB'
+#!/bin/bash
+# Args: install -y <pkg>  → log pkg, exit 1 (simulate "not found")
+if [[ "$1" == "install" ]]; then
+    shift
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -y|-q|--no-install-recommends) shift ;;
+            *) echo "$1" >> "${AWG_DIR}/.apt_calls"; shift ;;
+        esac
+    done
+fi
+exit 1
+STUB
+    chmod +x "$MOCK_BIN/apt-get"
+
+    # Mock dpkg --print-architecture to return our chosen arch.
+    cat > "$MOCK_BIN/dpkg" << 'STUB'
+#!/bin/bash
+if [[ "$1" == "--print-architecture" ]]; then
+    echo "${MOCK_ARCH:-amd64}"
+fi
+exit 0
+STUB
+    chmod +x "$MOCK_BIN/dpkg"
+
+    # Required gate: this function refuses to call apt without it.
+    export AWG_ALLOW_APT_IN_ENSURE=1
+
+    # shellcheck disable=SC1091
+    source "$BATS_TEST_DIRNAME/../awg_common.sh"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+# ---------- standard (non-cloud) kernel: cloud meta NOT in candidates ----------
+
+@test "v5.12.1: Debian arm64 standard kernel does not request linux-headers-cloud-arm64" {
+    export OS_ID=debian
+    export MOCK_ARCH=arm64
+    run _install_kernel_headers "6.12.85+deb13-arm64"
+    [ "$status" -eq 1 ]
+    [ -f "$AWG_DIR/.apt_calls" ]
+    grep -q "linux-headers-6.12.85+deb13-arm64" "$AWG_DIR/.apt_calls"
+    grep -q "linux-headers-arm64" "$AWG_DIR/.apt_calls"
+    ! grep -q "linux-headers-cloud-arm64" "$AWG_DIR/.apt_calls"
+}
+
+@test "v5.12.1: Debian amd64 standard kernel does not request linux-headers-cloud-amd64" {
+    export OS_ID=debian
+    export MOCK_ARCH=amd64
+    run _install_kernel_headers "6.1.0-28-amd64"
+    [ "$status" -eq 1 ]
+    grep -q "linux-headers-amd64" "$AWG_DIR/.apt_calls"
+    ! grep -q "linux-headers-cloud-amd64" "$AWG_DIR/.apt_calls"
+}
+
+# ---------- cloud kernel: cloud meta in candidates, BEFORE generic ----------
+
+@test "v5.12.1: Debian amd64 cloud kernel adds linux-headers-cloud-amd64 fallback" {
+    export OS_ID=debian
+    export MOCK_ARCH=amd64
+    run _install_kernel_headers "6.1.0-22-cloud-amd64"
+    [ "$status" -eq 1 ]
+    grep -q "linux-headers-cloud-amd64" "$AWG_DIR/.apt_calls"
+}
+
+@test "v5.12.1: Debian arm64 cloud kernel adds linux-headers-cloud-arm64 fallback" {
+    export OS_ID=debian
+    export MOCK_ARCH=arm64
+    run _install_kernel_headers "6.5.0-15-cloud-arm64"
+    [ "$status" -eq 1 ]
+    grep -q "linux-headers-cloud-arm64" "$AWG_DIR/.apt_calls"
+}
+
+@test "v5.12.1: Debian cloud kernel: cloud meta tried before generic arch meta" {
+    export OS_ID=debian
+    export MOCK_ARCH=amd64
+    run _install_kernel_headers "6.1.0-22-cloud-amd64"
+    [ "$status" -eq 1 ]
+    # Order check: cloud line precedes the generic one.
+    cloud_line=$(grep -n "^linux-headers-cloud-amd64$" "$AWG_DIR/.apt_calls" | head -1 | cut -d: -f1)
+    generic_line=$(grep -n "^linux-headers-amd64$" "$AWG_DIR/.apt_calls" | head -1 | cut -d: -f1)
+    [ -n "$cloud_line" ]
+    [ -n "$generic_line" ]
+    [ "$cloud_line" -lt "$generic_line" ]
+}
+
+# ---------- candidate set sanity (non-regression for existing behaviour) ----------
+
+@test "v5.12.1: Debian still tries exact kernel_ver first" {
+    export OS_ID=debian
+    export MOCK_ARCH=amd64
+    run _install_kernel_headers "6.1.0-22-cloud-amd64"
+    first=$(head -1 "$AWG_DIR/.apt_calls")
+    [ "$first" = "linux-headers-6.1.0-22-cloud-amd64" ]
+}
+
+@test "v5.12.1: Ubuntu codepath unaffected by Debian cloud branch" {
+    export OS_ID=ubuntu
+    export MOCK_ARCH=amd64
+    run _install_kernel_headers "6.8.0-57-generic"
+    [ "$status" -eq 1 ]
+    grep -q "linux-headers-6.8.0-57-generic" "$AWG_DIR/.apt_calls"
+    grep -q "linux-headers-generic" "$AWG_DIR/.apt_calls"
+    ! grep -q "linux-headers-cloud-" "$AWG_DIR/.apt_calls"
+}
+
+# ---------- EN mirror: same behaviour from awg_common_en.sh ----------
+#
+# The shared helper exists in both awg_common.sh (RU log strings) and
+# awg_common_en.sh (EN log strings). The kernel-headers logic is identical
+# byte-for-byte; this guard catches the case where someone updates only one.
+
+@test "v5.12.1: EN mirror Debian cloud kernel adds linux-headers-cloud-amd64" {
+    # Re-source the EN helper into a fresh subshell so we don't pollute the
+    # already-loaded RU functions in this test file.
+    rm -f "$AWG_DIR/.apt_calls"
+    (
+        export AWG_ALLOW_APT_IN_ENSURE=1 OS_ID=debian MOCK_ARCH=amd64
+        # shellcheck disable=SC1091
+        source "$BATS_TEST_DIRNAME/../awg_common_en.sh"
+        _install_kernel_headers "6.1.0-22-cloud-amd64" || true
+    )
+    [ -f "$AWG_DIR/.apt_calls" ]
+    grep -q "linux-headers-cloud-amd64" "$AWG_DIR/.apt_calls"
+}
+
+@test "v5.12.1: EN mirror Debian standard kernel does NOT add cloud meta" {
+    rm -f "$AWG_DIR/.apt_calls"
+    (
+        export AWG_ALLOW_APT_IN_ENSURE=1 OS_ID=debian MOCK_ARCH=arm64
+        # shellcheck disable=SC1091
+        source "$BATS_TEST_DIRNAME/../awg_common_en.sh"
+        _install_kernel_headers "6.12.85+deb13-arm64" || true
+    )
+    [ -f "$AWG_DIR/.apt_calls" ]
+    ! grep -q "linux-headers-cloud-arm64" "$AWG_DIR/.apt_calls"
+}

--- a/tests/test_v5121_skip_apply_regression.bats
+++ b/tests/test_v5121_skip_apply_regression.bats
@@ -1,0 +1,141 @@
+#!/usr/bin/env bats
+# v5.12.1 regression test: AWG_SKIP_APPLY=1 must not trigger
+# `ensure_amneziawg_kernel_module || die` in `manage add` / `manage remove`.
+#
+# Background: v5.12.0 added DKMS auto-repair and pre-called the module check
+# unconditionally before add/remove. This regressed the documented offline /
+# batch edit flow (AWG_SKIP_APPLY=1, see ADVANCED.md) which is supposed to
+# work on a dev machine without the kernel module loaded — apply_config
+# itself respects AWG_SKIP_APPLY=1 (early return 0).
+#
+# Fix: gate the pre-call on AWG_SKIP_APPLY for `add` and `remove` only.
+# `restart` is intentionally NOT gated because it is an explicit apply
+# operation (`systemctl restart`) — AWG_SKIP_APPLY has no meaningful semantics
+# for restart and the existing post-mutation block in restart does not honour
+# AWG_SKIP_APPLY either.
+
+# ---------- add: gate present ----------
+
+@test "v5.12.1: RU add gates ensure_amneziawg_kernel_module on AWG_SKIP_APPLY" {
+    block=$(awk '/^    add\)/,/^[[:space:]]+;;[[:space:]]*$/' \
+        "$BATS_TEST_DIRNAME/../manage_amneziawg.sh")
+    [[ "$block" == *'AWG_SKIP_APPLY'* ]]
+    [[ "$block" == *'ensure_amneziawg_kernel_module'* ]]
+    # Specifically: ensure_amneziawg_kernel_module is inside an if-block
+    # that tests AWG_SKIP_APPLY != "1".
+    [[ "$block" == *'"${AWG_SKIP_APPLY:-0}" != "1"'*'ensure_amneziawg_kernel_module'* ]]
+}
+
+@test "v5.12.1: EN add gates ensure_amneziawg_kernel_module on AWG_SKIP_APPLY" {
+    block=$(awk '/^    add\)/,/^[[:space:]]+;;[[:space:]]*$/' \
+        "$BATS_TEST_DIRNAME/../manage_amneziawg_en.sh")
+    [[ "$block" == *'AWG_SKIP_APPLY'* ]]
+    [[ "$block" == *'ensure_amneziawg_kernel_module'* ]]
+    [[ "$block" == *'"${AWG_SKIP_APPLY:-0}" != "1"'*'ensure_amneziawg_kernel_module'* ]]
+}
+
+# ---------- remove: gate present ----------
+
+@test "v5.12.1: RU remove gates ensure_amneziawg_kernel_module on AWG_SKIP_APPLY" {
+    block=$(awk '/^    remove\)/,/^[[:space:]]+;;[[:space:]]*$/' \
+        "$BATS_TEST_DIRNAME/../manage_amneziawg.sh")
+    [[ "$block" == *'AWG_SKIP_APPLY'* ]]
+    [[ "$block" == *'ensure_amneziawg_kernel_module'* ]]
+    [[ "$block" == *'"${AWG_SKIP_APPLY:-0}" != "1"'*'ensure_amneziawg_kernel_module'* ]]
+}
+
+@test "v5.12.1: EN remove gates ensure_amneziawg_kernel_module on AWG_SKIP_APPLY" {
+    block=$(awk '/^    remove\)/,/^[[:space:]]+;;[[:space:]]*$/' \
+        "$BATS_TEST_DIRNAME/../manage_amneziawg_en.sh")
+    [[ "$block" == *'AWG_SKIP_APPLY'* ]]
+    [[ "$block" == *'ensure_amneziawg_kernel_module'* ]]
+    [[ "$block" == *'"${AWG_SKIP_APPLY:-0}" != "1"'*'ensure_amneziawg_kernel_module'* ]]
+}
+
+# ---------- restart: NOT gated (explicit apply) ----------
+
+@test "v5.12.1: RU restart still calls ensure_amneziawg_kernel_module unconditionally" {
+    block=$(awk '/^    restart\)/,/^[[:space:]]+;;[[:space:]]*$/' \
+        "$BATS_TEST_DIRNAME/../manage_amneziawg.sh")
+    [[ "$block" == *'ensure_amneziawg_kernel_module module-only'* ]]
+    [[ "$block" != *'"${AWG_SKIP_APPLY:-0}" != "1"'* ]]
+}
+
+@test "v5.12.1: EN restart still calls ensure_amneziawg_kernel_module unconditionally" {
+    block=$(awk '/^    restart\)/,/^[[:space:]]+;;[[:space:]]*$/' \
+        "$BATS_TEST_DIRNAME/../manage_amneziawg_en.sh")
+    [[ "$block" == *'ensure_amneziawg_kernel_module module-only'* ]]
+    [[ "$block" != *'"${AWG_SKIP_APPLY:-0}" != "1"'* ]]
+}
+
+# ---------- syntax sanity ----------
+
+@test "v5.12.1: manage scripts pass bash -n after gate edits" {
+    bash -n "$BATS_TEST_DIRNAME/../manage_amneziawg.sh"
+    bash -n "$BATS_TEST_DIRNAME/../manage_amneziawg_en.sh"
+}
+
+# ---------- repair-module path remains explicit (sanity) ----------
+
+@test "v5.12.1: repair-module path keeps AWG_ALLOW_APT_IN_ENSURE=1 invocation" {
+    # repair-module is the user-explicit recovery path — it must still call
+    # ensure_amneziawg_kernel_module with AWG_ALLOW_APT_IN_ENSURE=1 regardless
+    # of AWG_SKIP_APPLY (the user is asking us to repair, that means apply).
+    for f in manage_amneziawg.sh manage_amneziawg_en.sh; do
+        block=$(awk '/^    repair-module\|repair\)/,/^[[:space:]]+;;[[:space:]]*$/' \
+            "$BATS_TEST_DIRNAME/../$f")
+        [[ "$block" == *'AWG_ALLOW_APT_IN_ENSURE=1 ensure_amneziawg_kernel_module full'* ]]
+    done
+}
+
+# ---------- runtime gate semantics ----------
+#
+# The structural greps above prove the gate text is in the right block. These
+# behaviour tests prove the gate evaluates as intended for every value the
+# documentation talks about (=1 skip, anything-else run).
+#
+# We replay just the gate snippet in isolation — that's the contract being
+# tested. Sourcing the full manage script is impractical (it kicks off
+# `case $COMMAND in ...` with side effects on real /etc paths).
+
+run_gate() {
+    # Replays exactly the gate the production scripts use:
+    #   if [[ "${AWG_SKIP_APPLY:-0}" != "1" ]]; then ensure_amneziawg_kernel_module; fi
+    # Returns 0 when ensure was called, 1 when it was skipped.
+    local called=0
+    ensure_amneziawg_kernel_module() { called=1; return 0; }
+    if [[ "${AWG_SKIP_APPLY:-0}" != "1" ]]; then
+        ensure_amneziawg_kernel_module
+    fi
+    [ "$called" -eq 1 ]
+}
+
+@test "v5.12.1 runtime: AWG_SKIP_APPLY unset -> ensure_amneziawg_kernel_module is called" {
+    unset AWG_SKIP_APPLY
+    run_gate
+}
+
+@test "v5.12.1 runtime: AWG_SKIP_APPLY=0 -> ensure_amneziawg_kernel_module is called" {
+    export AWG_SKIP_APPLY=0
+    run_gate
+}
+
+@test "v5.12.1 runtime: AWG_SKIP_APPLY=1 -> ensure_amneziawg_kernel_module is skipped" {
+    export AWG_SKIP_APPLY=1
+    ! run_gate
+}
+
+@test "v5.12.1 runtime: AWG_SKIP_APPLY=yes (string non-1) -> ensure is called (string equality with literal 1)" {
+    export AWG_SKIP_APPLY=yes
+    run_gate
+}
+
+@test "v5.12.1 runtime: AWG_SKIP_APPLY=true (string non-1) -> ensure is called" {
+    export AWG_SKIP_APPLY=true
+    run_gate
+}
+
+@test "v5.12.1 runtime: AWG_SKIP_APPLY=YES (uppercase, string non-1) -> ensure is called" {
+    export AWG_SKIP_APPLY=YES
+    run_gate
+}

--- a/tests/test_v5121_xz_kernel_compat.bats
+++ b/tests/test_v5121_xz_kernel_compat.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+# v5.12.1 Issue #76 — kernel-compatible xz preset for ARM prebuilts.
+#
+# Background: until v5.12.0 build-arm-deb.sh used `xz -9` which produced
+# valid xz streams (round-trips through `xz -t` and `xz -d`) but the in-tree
+# kernel decompressor on Debian 13 trixie 6.12.85+deb13-arm64 returned
+# `decompression failed with status 6`. Manual decompression + `insmod`
+# worked, ruling out a content bug.
+#
+# Fix: switch to the kernel's own modinst preset:
+#   xz --check=crc32 --lzma2=dict=1MiB
+# matches scripts/Makefile.modinst defaults — crc32 (kernel decompressor
+# does not consume xz-default crc64 streams) and 1 MiB dictionary (in-tree
+# decoder memory budget).
+#
+# Plus a build-time sanity gate: refuse to ship a .ko.xz that does not
+# round-trip via `xz -t` and `xz -d -c` after compression.
+
+setup() {
+    BUILD="${BATS_TEST_DIRNAME}/../scripts/build-arm-deb.sh"
+    [ -f "$BUILD" ] || { echo "build-arm-deb.sh missing" >&2; return 1; }
+}
+
+@test "v5.12.1: build script no longer uses bare 'xz -9' on the kernel module" {
+    # The v5.12.0 invocation `xz -9 "$MODULE_INSTALL_PATH/amneziawg.ko"` is the
+    # exact line Issue #76 traced to. Make sure it is gone.
+    ! grep -qE 'xz -9 "\$MODULE_INSTALL_PATH/amneziawg\.ko"' "$BUILD"
+}
+
+@test "v5.12.1: build script uses --check=crc32 (kernel-compatible)" {
+    grep -qE 'xz .*--check=crc32' "$BUILD"
+}
+
+@test "v5.12.1: build script uses --lzma2=dict=1MiB (in-tree decoder budget)" {
+    grep -qE 'xz .*--lzma2=dict=1MiB' "$BUILD"
+}
+
+@test "v5.12.1: build script runs xz -t round-trip sanity on the produced .ko.xz" {
+    grep -qE 'xz -t "\$KO_XZ"' "$BUILD"
+}
+
+@test "v5.12.1: build script runs xz -d round-trip sanity on the produced .ko.xz" {
+    grep -qE 'xz -d -c "\$KO_XZ"' "$BUILD"
+}
+
+@test "v5.12.1: build script aborts on sanity failure (no broken prebuilt published)" {
+    # "exit 1" must appear inside the sanity branch so a corrupt compress
+    # stream cannot be packaged into the .deb.
+    block=$(awk '/KO_FILE=/,/^fi$/' "$BUILD")
+    [[ "$block" == *'sanity check failed'* ]]
+    [[ "$block" == *'exit 1'* ]]
+}
+
+@test "v5.12.1: xz with chosen flags round-trips locally (sanity on the tooling)" {
+    # Toolchain smoke test, NOT a kernel-decompressor compatibility proof.
+    # The actual incompatibility on Issue #76 is between userspace xz
+    # output and the in-tree decoder — only a real ARM kernel can prove
+    # round-trip there. This test confirms the build host's xz binary
+    # accepts our flags and produces a stream userspace can decode.
+    skip_if_no_xz() {
+        command -v xz >/dev/null 2>&1 || skip "xz not installed"
+    }
+    skip_if_no_xz
+
+    tmp=$(mktemp -d)
+    # 256 KiB of zero bytes — small, deterministic, fits in any dict size.
+    head -c 262144 /dev/zero > "$tmp/sample"
+    xz --check=crc32 --lzma2=dict=1MiB -f "$tmp/sample"
+    [ -f "$tmp/sample.xz" ]
+    xz -t "$tmp/sample.xz"
+    out=$(xz -d -c "$tmp/sample.xz" | wc -c)
+    [ "$out" -eq 262144 ]
+    rm -rf "$tmp"
+}


### PR DESCRIPTION
## Summary

Hotfix bundle for v5.12.0. Three surgical fixes for issues found in the first 48 hours after the release. No new features, no architectural changes.

1. **`AWG_SKIP_APPLY=1` regression in `manage add`/`remove`** — v5.12.0 added an unconditional `ensure_amneziawg_kernel_module || die` pre-call that broke the documented offline edit-only flow on dev/CI machines without the kernel module. Wrapped the pre-call in `if [[ "${AWG_SKIP_APPLY:-0}" != "1" ]]`. `manage restart` intentionally NOT gated. RU + EN mirror.
2. **`linux-headers-cloud-${arch}` fallback for Debian cloud kernels in `manage repair-module`** — `_install_kernel_headers` on Debian only tried exact-version + generic `linux-headers-${arch}`. Cloud kernels (`*-cloud-*` in `uname -r`) on AWS/Azure/GCP/cloud-Hetzner now also try the cloud meta-package, before generic. Standard kernels — behaviour unchanged.
3. **Issue #76 — ARM prebuilt xz fix** — `scripts/build-arm-deb.sh` switched from `xz -9` (CRC64, 64 MiB dict) to kernel-compatible `xz --check=crc32 --lzma2=dict=1MiB` (matches mainline `scripts/Makefile.modinst`). Plus a build-time sanity gate: post-compress `xz -t` + `xz -d -c` round-trip; `exit 1` if either fails.

## Implementation

- One squash-mergeable commit on `v5.12.1/development`.
- 12 files modified, 3 new test files (~589 insertions, 58 deletions).
- `SCRIPT_VERSION` bumped 5.12.0 → 5.12.1 in install / manage / awg_common (RU + EN). `COMMON_SCRIPT_SHA256` / `MANAGE_SCRIPT_SHA256` pins recomputed in both installers. Wget URLs + version badge in README.md / README.en.md bumped.
- Bilingual CHANGELOG entries (RU + EN, parity verified).

## Tests

- **+30 new bats tests** (387 in the matrix, was 357 in v5.12.0):
  - `test_v5121_skip_apply_regression.bats` (+14) — gate structure on `add`/`remove`/`restart` blocks + runtime semantics for unset/0/1/yes/true/YES.
  - `test_v5121_cloud_headers.bats` (+9) — functional `_install_kernel_headers` via mocked apt-get/dpkg, RU + EN mirror.
  - `test_v5121_xz_kernel_compat.bats` (+7) — structural greps on new xz flags + sanity gate, local round-trip.
  - `test_v5115_regen_multiarg.bats` — version assertion bumped to 5.12.1.
- `bash -n` and `shellcheck -S warning` clean on all 7 modified shell files.
- 2 implicit skips remain (cyrillic / em-dash test names from earlier releases — bats-on-Windows known issue, not v5.12.1).

## Compatibility

Fully backwards-compatible. All three fixes change behaviour only in narrow regression cases:
- offline edit flow (`AWG_SKIP_APPLY=1` users on dev/CI)
- `manage repair-module` on cloud kernels
- ARM prebuilt install on Debian 13 trixie kernel `6.12.85+deb13-arm64`

The standard install + client flow is unchanged.

## VPS verification plan

- frankt (Ubuntu 24.04 amd64): `AWG_BRANCH=v5.12.1/development bash install_amneziawg.sh`, then `AWG_SKIP_APPLY=1 manage add foo` smoke-test on a stopped service.
- biHetzner (Debian 13 trixie ARM64, kernel `6.12.85+deb13-arm64` — the exact build that reproduced Issue #76): re-test prebuilt path after tag push + `arm-build.yml` re-publishes packages with the new xz preset.

## Test plan

- [x] `bash -n` on all 6 scripts + `scripts/build-arm-deb.sh`
- [x] `shellcheck -S warning` clean
- [x] `bats tests/` — 385 PASS (387 expected, 2 unrelated skips), 0 FAIL
- [ ] CI lint/syntax workflow on push
- [ ] VPS test on frankt (Ubuntu 24.04) — AWG_SKIP_APPLY flow, repair-module, manage CRUD
- [ ] After tag: VPS test on biHetzner (Debian 13 trixie ARM64) — Issue #76 reproduction with new prebuilts
- [ ] Tag v5.12.1 → release.yml + arm-build.yml both green
- [ ] Bilingual release notes published
- [ ] Issue #76 closed
