### PR TITLE
v5.13.0 — Ubuntu 25.10/26.04 PPA noble fallback + --force safety guard

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -14,6 +14,54 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [5.13.0] — 2026-05-12
+
+**v5.13.0** — AmneziaWG 2.0 VPN installer release with Ubuntu 25.10 (questing) and 26.04 support, plus a `--force` safety guard against accidental re-install on a configured server. Ubuntu 24.04, Debian 12 / 13, x86_64 + ARM (Raspberry Pi, Oracle Ampere, Hetzner CAX) support — unchanged.
+
+### Highlights
+
+- 🛡️ **PPA noble fallback for Ubuntu 25.10 / 26.04** ([Issue #46](https://github.com/bivlked/amneziawg-installer/issues/46)). The Amnezia PPA does not yet publish packages for `questing` (25.10) or upcoming Ubuntu codenames. The installer now auto-detects the 404 on `dists/<codename>/Release`, remaps the suite to `noble` in `/etc/apt/sources.list.d/amnezia-ppa.sources` and re-runs `apt update`. If the server has leftover kernel headers from a previous 24.04 install (typical after `do-release-upgrade`), the installer also pulls in `gcc-13` from `questing/universe` so the DKMS autoinstall succeeds for every kernel. No manual `sources.list` edits, no DKMS surprises. The script also repairs a "sticky" `.sources` file from a previous (≤ v5.12.1) run that left `Suites: questing` behind after an apt failure.
+- 🔒 **`--force` safety guard** ([Issue #78](https://github.com/bivlked/amneziawg-installer/issues/78)). Re-running the installer on a server with AmneziaWG already configured now requires an explicit `--force` (or `AWG_FORCE_REINSTALL=1`). Without it, the script early-exits with a clear "already installed and running" message. Server keys, peer configs, and obfuscation parameters survive a re-run, but Step 1 re-tunes sysctl/swap/BBR, `apt-get upgrade` may pull a new kernel (and require another reboot), and Step 7 restarts `awg-quick@awg0` — handshakes drop for a few seconds. The guard removes that foot-gun.
+- 🧹 **`manage_amneziawg.sh` logging: WARN → stderr.** In v5.12.1 `manage_amneziawg.sh:log_msg` routed only ERROR to stderr and leaked WARN to stdout — broke CI/automation parsing (stdout = "data", stderr = "diagnostics"). WARN and ERROR now both go to stderr, symmetric with `install_amneziawg.sh:log_msg`.
+- 💾 **Precise `/swapfile` check in `/etc/fstab`.** The old substring check `grep -q '/swapfile'` matched commented lines and partial-name hits (`/swapfile.bak`); on re-run the installer could mistakenly skip adding a valid entry — swap then failed to mount on reboot. Switched to an anchored field-aware awk check: `!/^[[:space:]]*#/ && $1 == "/swapfile" && $3 == "swap"`. Idempotent and comment-resistant.
+
+### Installation
+
+```bash
+wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.13.0/install_amneziawg_en.sh
+chmod +x install_amneziawg_en.sh
+sudo bash ./install_amneziawg_en.sh
+```
+
+3 commands → ~20 minutes → a working VPN server with traffic obfuscation. Full guide — [README → Installation](README.en.md#installation).
+
+### Upgrading an existing server
+
+Run the latest `install_amneziawg.sh` with `--force` (if AmneziaWG is already running) — Step 5 fetches the fresh `manage_amneziawg.sh` and `awg_common.sh` with SHA256 verification. Full commands — [ADVANCED.en.md → Updating the scripts](ADVANCED.en.md#-updating-scripts).
+
+### Tests
+
+**+68 new bats** (455 in the matrix, was 387 on v5.12.1):
+
+- `test_v5130_ppa_noble_fallback.bats` (+33) — RU/EN structural greps on the pre-check block and suite-mismatch detection, parity counts, functional tests with mocked `curl` (404 → noble, timeout → noble, success → questing), LTS whitelist (noble/jammy/focal skip pre-check), suite mismatch deletes file on mismatch and preserves on match, corrupt `.sources` (missing `Suites:`) gets recreated, legacy `.sources` mismatch is removed, gcc-13 pre-install fires when stale headers are detected.
+- `test_v5130_force_guard.bats` (+19) — RU/EN structural greps on the `--force|-f` CLI flag, the `AWG_FORCE_REINSTALL=1` env bridge, the idempotency guard `[[ -f $SERVER_CONF_FILE ]] && systemctl is-active --quiet awg-quick@awg0`, the help-section mention of `-f, --force`, RU/EN parity by `FORCE_REINSTALL` occurrence count; functional matrix of 6 cases (clean install / configured+active+no-force / configured+inactive+no-force → repair flow / configured+active+--force / env bridge / strict `=1` env vs `yes`).
+- `test_v5130_bundled_fixes.bats` (+16) — rcgr: RU/EN log_msg routes WARN to stderr (structural + functional, INFO still on stdout); i31a: awk check on `/swapfile` correctly detects a valid entry, rejects commented lines, rejects partial-name matches (`/swapfile.bak`), handles indented lines and an empty fstab.
+
+### Compatibility
+
+- **OS**: Ubuntu 24.04 LTS, 25.10, 26.04 (with noble fallback). Debian 12 (bookworm), 13 (trixie).
+- **Arch**: amd64, arm64 (Raspberry Pi 4/5, Oracle Cloud Ampere, Hetzner CAX, AWS Graviton, other ARM VPS)
+- **Russian carriers**: `--preset=mobile` works on Yota, Beeline, MTS, Tattelecom, Tele2 (Moscow), Megafon (Moscow). See the operator matrix in README.
+
+### Out of scope
+
+- v5.13.1: external review fixes (kernel ambiguity in `build-arm-deb.sh`), backlog refinements.
+- v5.14.0: `--preset=mobile-awg1` (I1=none fallback for Tele2 Krasnoyarsk / Megafon regions).
+
+Full roadmap — [Issue #79](https://github.com/bivlked/amneziawg-installer/issues/79).
+
+---
+
 ## [5.12.1] — 2026-05-08
 
 **v5.12.1** — patch release of the AmneziaWG 2.0 VPN installer: three small fixes for issues found in the first 48 hours after v5.12.0. No new features, no architectural changes. Support matrix unchanged: Ubuntu 24.04 / 25.10, Debian 12 / 13, x86_64 + ARM (Raspberry Pi, Oracle Ampere, Hetzner CAX).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,54 @@
 
 ---
 
+## [5.13.0] — 2026-05-12
+
+**v5.13.0** — релиз AmneziaWG 2.0 VPN-инсталлятора с поддержкой Ubuntu 25.10 (questing) и 26.04, и защитным флагом `--force` против случайной переустановки на работающем сервере. Поддержка Ubuntu 24.04, Debian 12 / 13, x86_64 + ARM (Raspberry Pi, Oracle Ampere, Hetzner CAX) — без изменений.
+
+### Главное
+
+- 🛡️ **PPA noble fallback для Ubuntu 25.10 / 26.04** ([Issue #46](https://github.com/bivlked/amneziawg-installer/issues/46)). PPA Amnezia пока не публикует пакеты для `questing` (25.10) и будущих кодовых имён Ubuntu. Инсталлер автоматически детектит 404 на `dists/<codename>/Release`, переключает suite на `noble` в `/etc/apt/sources.list.d/amnezia-ppa.sources` и повторяет `apt update`. Если на сервере остались kernel headers от прошлого 24.04 (сценарий после `do-release-upgrade`), инсталлер также доставит `gcc-13` из `questing/universe`, чтобы DKMS autoinstall успешно собрал модуль для всех ядер. Без ручных правок sources.list, без DKMS-сюрпризов. Скрипт также чинит «прилипший» `.sources`-файл с устаревшим suite, если предыдущий запуск (≤ v5.12.1) оставил `Suites: questing` после ошибки apt.
+- 🔒 **`--force` safety guard** ([Issue #78](https://github.com/bivlked/amneziawg-installer/issues/78)). Повторный запуск инсталлера на сервере с уже сконфигурированным AmneziaWG теперь требует явный флаг `--force` (или `AWG_FORCE_REINSTALL=1`). Без него скрипт early-exit'ит с понятным сообщением: «уже установлено и запущено». Серверные ключи, конфиги пиров и параметры обфускации сохраняются при повторном запуске, но Шаг 1 заново настраивает sysctl/swap/BBR, `apt-get upgrade` может подтянуть новое ядро (и потребовать ещё один reboot), а Шаг 7 рестартит `awg-quick@awg0` — handshake'и отваливаются на несколько секунд. Guard убирает эту ловушку.
+- 🧹 **Логи `manage_amneziawg.sh`: WARN → stderr.** В v5.12.1 в `manage_amneziawg.sh:log_msg` только ERROR уходил в stderr, а WARN утекал в stdout — ломало CI/automation парсинг (stdout = «данные», stderr = «диагностика»). Теперь WARN и ERROR оба идут в stderr, симметрично с `install_amneziawg.sh:log_msg`.
+- 💾 **Точная проверка `/swapfile` в `/etc/fstab`.** Старая substring-проверка `grep -q '/swapfile'` ловила закомментированные строки и partial matches (`/swapfile.bak`); на повторном запуске installer мог решить, что fstab уже настроен, и пропустить добавление валидной записи — swap не монтировался при reboot. Перешёл на anchored field-aware awk-check: `!/^[[:space:]]*#/ && $1 == "/swapfile" && $3 == "swap"`. Идемпотентно и устойчиво к комментариям.
+
+### Установка
+
+```bash
+wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.13.0/install_amneziawg.sh
+chmod +x install_amneziawg.sh
+sudo bash ./install_amneziawg.sh
+```
+
+3 команды → ~20 минут → готовый VPN-сервер с обфускацией трафика. Подробнее — [README → Установка](README.md#установка).
+
+### Обновление существующего сервера
+
+Запустите `install_amneziawg.sh` свежей версии с флагом `--force` (если AmneziaWG уже работает) — на 5-м шаге `manage_amneziawg.sh` и `awg_common.sh` обновятся автоматически (с проверкой SHA256). Полные команды — [ADVANCED.md → Как обновить скрипты](ADVANCED.md#-как-обновить-скрипты).
+
+### Тесты
+
+**+68 новых bats** (455 в матрице, было 387 на v5.12.1):
+
+- `test_v5130_ppa_noble_fallback.bats` (+33) — RU/EN структурные greps на pre-check блок и suite-mismatch detection, parity-counts, функциональные тесты с мокнутым `curl` (404 → noble, timeout → noble, success → questing), LTS-whitelist (noble/jammy/focal skip pre-check), suite-mismatch удаляет файл при несовпадении и сохраняет при совпадении, повреждённый `.sources` (без `Suites:`) тоже пересоздаётся, legacy `.sources` mismatch удаляется, gcc-13 pre-install активируется при stale headers.
+- `test_v5130_force_guard.bats` (+19) — RU/EN структурные greps на CLI-флаг `--force|-f`, env-bridge `AWG_FORCE_REINSTALL=1`, идемпотентный guard `[[ -f $SERVER_CONF_FILE ]] && systemctl is-active --quiet awg-quick@awg0`, help-секция упоминает `-f, --force`, RU/EN parity по числу `FORCE_REINSTALL` вхождений; функциональная матрица 6 кейсов (clean install / configured+active+no-force / configured+inactive+no-force → repair flow / configured+active+--force / env-bridge / strict `=1` env vs `yes`).
+- `test_v5130_bundled_fixes.bats` (+16) — rcgr: RU/EN log_msg routes WARN to stderr (structural + functional, INFO остаётся в stdout); i31a: awk-check для `/swapfile` корректно детектит valid entry / отбрасывает закомментированные / отбрасывает partial-name матчи (`/swapfile.bak`), индентированные строки, пустой fstab.
+
+### Совместимость
+
+- **ОС**: Ubuntu 24.04 LTS, 25.10, 26.04 (с noble fallback). Debian 12 (bookworm), 13 (trixie).
+- **Архитектура**: amd64, arm64 (Raspberry Pi 4/5, Oracle Cloud Ampere, Hetzner CAX, AWS Graviton, прочие ARM-VPS)
+- **Мобильные операторы РФ**: `--preset=mobile` работает на Yota, Beeline, МТС, Tattelecom, Tele2 (Москва), Megafon (Москва). См. таблицу операторов в README.
+
+### Вне этого релиза
+
+- v5.13.1: external review fixes (kernel ambiguity в `build-arm-deb.sh`), backlog refinements.
+- v5.14.0: `--preset=mobile-awg1` (I1=none fallback для Tele2 Красноярск / Megafon регионы).
+
+Полный roadmap — [Issue #79](https://github.com/bivlked/amneziawg-installer/issues/79).
+
+---
+
 ## [5.12.1] — 2026-05-08
 
 **v5.12.1** — патч-релиз AmneziaWG 2.0 VPN-инсталлятора: три точечных исправления, найденных в первые 48 часов после v5.12.0. Без новых фич, без архитектурных сдвигов. Поддержка Ubuntu 24.04 / 25.10, Debian 12 / 13, x86_64 + ARM (Raspberry Pi, Oracle Ampere, Hetzner CAX) — без изменений.

--- a/README.en.md
+++ b/README.en.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/Architecture-x86__64_|_ARM64_|_ARMv7-green" alt="x86_64 | ARM64 | ARMv7">
   <a href="https://github.com/bivlked/amneziawg-installer/blob/main/LICENSE"><img src="https://img.shields.io/github/license/bivlked/amneziawg-installer" alt="License"></a>
   <img src="https://img.shields.io/badge/Status-Stable-success" alt="Status">
-  <a href="https://github.com/bivlked/amneziawg-installer/releases"><img src="https://img.shields.io/badge/Installer_Version-5.12.1-blue" alt="Version"></a>
+  <a href="https://github.com/bivlked/amneziawg-installer/releases"><img src="https://img.shields.io/badge/Installer_Version-5.13.0-blue" alt="Version"></a>
   <img src="https://img.shields.io/badge/AmneziaWG-2.0-blueviolet" alt="AWG 2.0">
   <a href="https://github.com/bivlked/amneziawg-installer/actions/workflows/shellcheck.yml"><img src="https://github.com/bivlked/amneziawg-installer/actions/workflows/shellcheck.yml/badge.svg" alt="ShellCheck"></a>
   <a href="https://github.com/bivlked/amneziawg-installer/actions/workflows/test.yml"><img src="https://github.com/bivlked/amneziawg-installer/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
@@ -100,7 +100,7 @@ Works on Ubuntu 24.04/25.10 and Debian 12/13. Any cheap VPS with 1 GB RAM is eno
 ## 🚀 Quick Start
 
 ```bash
-wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg_en.sh
+wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.13.0/install_amneziawg_en.sh
 chmod +x install_amneziawg_en.sh
 sudo bash ./install_amneziawg_en.sh
 ```
@@ -231,8 +231,8 @@ This installation method ensures correct handling of interactive prompts and col
 
 2.  **Download the script:**
     ```bash
-    wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg_en.sh
-    # or: curl -fLo install_amneziawg_en.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg_en.sh
+    wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.13.0/install_amneziawg_en.sh
+    # or: curl -fLo install_amneziawg_en.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.13.0/install_amneziawg_en.sh
     ```
 3.  **Make it executable:**
     ```bash
@@ -246,7 +246,7 @@ This installation method ensures correct handling of interactive prompts and col
 
     > **Russian version:** For Russian output, use `install_amneziawg.sh`:
     > ```bash
-    > wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg.sh
+    > wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.13.0/install_amneziawg.sh
     > sudo bash ./install_amneziawg.sh
     > ```
     > The Russian version is functionally identical; only user-facing messages and logs are in Russian.
@@ -357,11 +357,11 @@ sudo bash /root/awg/manage_amneziawg.sh <command> [arguments]
 
 ```bash
 # Installation (English)
-wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg_en.sh
+wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.13.0/install_amneziawg_en.sh
 sudo bash ./install_amneziawg_en.sh       # Run (+ 2 reboots)
 
 # Installation (Russian)
-wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg.sh
+wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.13.0/install_amneziawg.sh
 sudo bash ./install_amneziawg.sh          # Run (+ 2 reboots)
 
 # Client management
@@ -428,13 +428,13 @@ For the changelog, see **[CHANGELOG.en.md](CHANGELOG.en.md)**.
   <b>A:</b> Download the updated scripts and replace them on the server:
   <pre>
   # English version:
-  wget -O /root/awg/manage_amneziawg.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/manage_amneziawg_en.sh
-  wget -O /root/awg/awg_common.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/awg_common_en.sh
+  wget -O /root/awg/manage_amneziawg.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.13.0/manage_amneziawg_en.sh
+  wget -O /root/awg/awg_common.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.13.0/awg_common_en.sh
   chmod 700 /root/awg/manage_amneziawg.sh /root/awg/awg_common.sh
 
   # Russian version:
-  wget -O /root/awg/manage_amneziawg.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/manage_amneziawg.sh
-  wget -O /root/awg/awg_common.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/awg_common.sh
+  wget -O /root/awg/manage_amneziawg.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.13.0/manage_amneziawg.sh
+  wget -O /root/awg/awg_common.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.13.0/awg_common.sh
   chmod 700 /root/awg/manage_amneziawg.sh /root/awg/awg_common.sh
   </pre>
   Server reinstallation is not required.
@@ -538,7 +538,7 @@ For the changelog, see **[CHANGELOG.en.md](CHANGELOG.en.md)**.
 <details>
 <summary><strong>📰 Featured in</strong></summary>
 
-- [VPN Status (RU) — AmneziaWG services and server-side options catalog](https://vpnstatus.online/protocols/amneziawg)
+- [VPN Status (RU) — AmneziaWG services and server-side options catalog](https://vpnstatus.site/protocols/amneziawg)
 - [XDA Developers — «I found a self-hosted VPN that works where WireGuard gets blocked»](https://www.xda-developers.com/self-hosted-vpn-works-where-wireguard-gets-blocked/)
 - [Pinggy — Top 5 Best Self-Hosted VPNs in 2026](https://pinggy.io/blog/top_5_best_self_hosted_vpns/)
 - [gHacks Tech News — AmneziaWG 2.0](https://www.ghacks.net/2026/03/25/amnezia-releases-amneziawg-2-0-to-bypass-advanced-internet-censorship-systems/)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/Architecture-x86__64_|_ARM64_|_ARMv7-green" alt="x86_64 | ARM64 | ARMv7">
   <a href="https://github.com/bivlked/amneziawg-installer/blob/main/LICENSE"><img src="https://img.shields.io/github/license/bivlked/amneziawg-installer" alt="License"></a>
   <img src="https://img.shields.io/badge/Status-Stable-success" alt="Status">
-  <a href="https://github.com/bivlked/amneziawg-installer/releases"><img src="https://img.shields.io/badge/Installer_Version-5.12.1-blue" alt="Version"></a>
+  <a href="https://github.com/bivlked/amneziawg-installer/releases"><img src="https://img.shields.io/badge/Installer_Version-5.13.0-blue" alt="Version"></a>
   <img src="https://img.shields.io/badge/AmneziaWG-2.0-blueviolet" alt="AWG 2.0">
   <a href="https://github.com/bivlked/amneziawg-installer/actions/workflows/shellcheck.yml"><img src="https://github.com/bivlked/amneziawg-installer/actions/workflows/shellcheck.yml/badge.svg" alt="ShellCheck"></a>
   <a href="https://github.com/bivlked/amneziawg-installer/actions/workflows/test.yml"><img src="https://github.com/bivlked/amneziawg-installer/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
@@ -100,7 +100,7 @@
 ## 🚀 Быстрый старт
 
 ```bash
-wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg.sh
+wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.13.0/install_amneziawg.sh
 chmod +x install_amneziawg.sh
 sudo bash ./install_amneziawg.sh
 ```
@@ -231,8 +231,8 @@ sudo bash ./install_amneziawg.sh --yes --route-all
 
 2.  **Скачайте скрипт:**
     ```bash
-    wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg.sh
-    # или: curl -fLo install_amneziawg.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg.sh
+    wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.13.0/install_amneziawg.sh
+    # или: curl -fLo install_amneziawg.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.13.0/install_amneziawg.sh
     ```
 3.  **Сделайте его исполняемым:**
     ```bash
@@ -246,7 +246,7 @@ sudo bash ./install_amneziawg.sh --yes --route-all
 
     > **English version:** Для вывода на английском используйте `install_amneziawg_en.sh`:
     > ```bash
-    > wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg_en.sh
+    > wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.13.0/install_amneziawg_en.sh
     > sudo bash ./install_amneziawg_en.sh
     > ```
     > Английская версия функционально идентична; только сообщения и логи на английском.
@@ -357,11 +357,11 @@ sudo bash /root/awg/manage_amneziawg.sh <команда> [аргументы]
 
 ```bash
 # Установка (русский)
-wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg.sh
+wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.13.0/install_amneziawg.sh
 sudo bash ./install_amneziawg.sh          # Запуск (+ 2 перезагрузки)
 
 # Установка (English)
-wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/install_amneziawg_en.sh
+wget https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.13.0/install_amneziawg_en.sh
 sudo bash ./install_amneziawg_en.sh       # Запуск (+ 2 перезагрузки)
 
 # Управление клиентами
@@ -428,13 +428,13 @@ sudo bash /root/awg/manage_amneziawg.sh restart              # Перезапу�
   <b>О:</b> Скачайте новый скрипт установки и замените скрипты управления на сервере:
   <pre>
   # Русская версия:
-  wget -O /root/awg/manage_amneziawg.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/manage_amneziawg.sh
-  wget -O /root/awg/awg_common.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/awg_common.sh
+  wget -O /root/awg/manage_amneziawg.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.13.0/manage_amneziawg.sh
+  wget -O /root/awg/awg_common.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.13.0/awg_common.sh
   chmod 700 /root/awg/manage_amneziawg.sh /root/awg/awg_common.sh
 
   # Английская версия:
-  wget -O /root/awg/manage_amneziawg.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/manage_amneziawg_en.sh
-  wget -O /root/awg/awg_common.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.12.1/awg_common_en.sh
+  wget -O /root/awg/manage_amneziawg.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.13.0/manage_amneziawg_en.sh
+  wget -O /root/awg/awg_common.sh https://raw.githubusercontent.com/bivlked/amneziawg-installer/v5.13.0/awg_common_en.sh
   chmod 700 /root/awg/manage_amneziawg.sh /root/awg/awg_common.sh
   </pre>
   Переустановка сервера не требуется.
@@ -538,7 +538,7 @@ sudo bash /root/awg/manage_amneziawg.sh restart              # Перезапу�
 <details>
 <summary><strong>📰 Упоминания</strong></summary>
 
-- [VPN Статус — каталог AmneziaWG-сервисов и серверных решений](https://vpnstatus.online/protocols/amneziawg)
+- [VPN Статус — каталог AmneziaWG-сервисов и серверных решений](https://vpnstatus.site/protocols/amneziawg)
 - [XDA Developers — «I found a self-hosted VPN that works where WireGuard gets blocked»](https://www.xda-developers.com/self-hosted-vpn-works-where-wireguard-gets-blocked/)
 - [Pinggy — Top 5 Best Self-Hosted VPNs in 2026](https://pinggy.io/blog/top_5_best_self_hosted_vpns/)
 - [gHacks Tech News — AmneziaWG 2.0](https://www.ghacks.net/2026/03/25/amnezia-releases-amneziawg-2-0-to-bypass-advanced-internet-censorship-systems/)

--- a/install_amneziawg.sh
+++ b/install_amneziawg.sh
@@ -8,15 +8,15 @@ fi
 # ==============================================================================
 # Скрипт для установки и настройки AmneziaWG 2.0 на Ubuntu/Debian серверах
 # Автор: @bivlked
-# Версия: 5.12.1
-# Дата: 2026-05-08
+# Версия: 5.13.0
+# Дата: 2026-05-12
 # Репозиторий: https://github.com/bivlked/amneziawg-installer
 # ==============================================================================
 
 # --- Безопасный режим и Константы ---
 set -o pipefail
 
-SCRIPT_VERSION="5.12.1"
+SCRIPT_VERSION="5.13.0"
 AWG_DIR="/root/awg"
 CONFIG_FILE="$AWG_DIR/awgsetup_cfg.init"
 STATE_FILE="$AWG_DIR/setup_state"
@@ -34,10 +34,11 @@ MANAGE_SCRIPT_PATH="$AWG_DIR/manage_amneziawg.sh"
 # Если AWG_BRANCH переопределён (не v$SCRIPT_VERSION), проверка пропускается.
 # Формат: sha256sum output (hex, 64 chars).
 COMMON_SCRIPT_SHA256="2f75bb5c827f7e3d36ecbb716b0b89096591694c1a636c31c784683738140eb9"
-MANAGE_SCRIPT_SHA256="59958e56a8d8d611c7f88438883b2662fff87c17cf103324916bf8d482c6fb02"
+MANAGE_SCRIPT_SHA256="291c83acb0449aa7e6b1780b06b2eb4f342b47a01cad1b2e2a6e6f980ab3f09e"
 
 # Флаги CLI
 UNINSTALL=0; HELP=0; DIAGNOSTIC=0; VERBOSE=0; NO_COLOR=0; AUTO_YES=0; NO_TWEAKS=0
+FORCE_REINSTALL=0
 _APT_UPDATED=0
 CLI_PORT=""; CLI_SUBNET=""; CLI_DISABLE_IPV6="default"
 CLI_ROUTING_MODE="default"; CLI_CUSTOM_ROUTES=""; CLI_ENDPOINT=""; CLI_NO_TWEAKS=0
@@ -70,6 +71,7 @@ while [[ $# -gt 0 ]]; do
         --endpoint=*)    CLI_ENDPOINT="${1#*=}" ;;
         --yes|-y)        AUTO_YES=1 ;;
         --no-tweaks)     NO_TWEAKS=1; CLI_NO_TWEAKS=1 ;;
+        --force|-f)      FORCE_REINSTALL=1 ;;
         --preset=*)      CLI_PRESET="${1#*=}" ;;
         --jc=*)          CLI_JC="${1#*=}" ;;
         --jmin=*)        CLI_JMIN="${1#*=}" ;;
@@ -261,6 +263,9 @@ show_help() {
   --route-custom=СЕТИ   Использовать режим 'Пользовательский' неинтерактивно
   --endpoint=IP         Указать внешний IP сервера (для серверов за NAT)
   -y, --yes             Автоматическое подтверждение (перезагрузки, UFW и т.д.)
+  -f, --force           Принудительная переустановка поверх уже работающего AmneziaWG
+                        (по умолчанию запуск на сконфигурированном сервере прерывается;
+                        ENV: AWG_FORCE_REINSTALL=1 эквивалентен флагу)
   --no-tweaks           Пропустить hardening/оптимизацию (без UFW, Fail2Ban, sysctl tweaks)
   --preset=ТИП          Набор параметров обфускации: default, mobile
                         mobile: Jc=3, узкий Jmax — для мобильных операторов (Tele2, Yota, Megafon)
@@ -446,7 +451,28 @@ install_packages() {
         apt_update_tolerant || log_warn "Не удалось обновить apt."
         _APT_UPDATED=1
     fi
-    DEBIAN_FRONTEND=noninteractive apt install -y "${to_install[@]}" || die "Ошибка установки пакетов."
+    if ! DEBIAN_FRONTEND=noninteractive apt install -y "${to_install[@]}"; then
+        # v5.13.0: типичный сбой на 25.10/26.04 после in-place upgrade с 24.04 —
+        # dpkg postinst пакета amneziawg-dkms запускает `dkms autoinstall`,
+        # который итерируется по ВСЕМ ядрам в /lib/modules/. Старые 6.8.x
+        # headers скомпилированы gcc-13, а в 25.10 по умолчанию только
+        # gcc-15 → autoinstall фолится, dpkg не configure'ит зависящие
+        # amneziawg-tools / amneziawg. Принудительно собираем модуль для
+        # running ядра и завершаем dpkg --configure -a.
+        if printf '%s\n' "${to_install[@]}" | grep -qx "amneziawg-dkms"; then
+            log_warn "apt install не завершился — пробую DKMS-сборку только для текущего ядра $(uname -r)..."
+            local _mver
+            _mver="$(ls /var/lib/dkms/amneziawg/ 2>/dev/null | head -n1)"
+            if [[ -n "$_mver" ]] \
+               && dkms install -m amneziawg -v "$_mver" -k "$(uname -r)" --force \
+               && DEBIAN_FRONTEND=noninteractive dpkg --configure -a; then
+                log "DKMS-модуль собран для $(uname -r), dpkg сконфигурирован."
+                log "Пакеты установлены."
+                return 0
+            fi
+        fi
+        die "Ошибка установки пакетов."
+    fi
     log "Пакеты установлены."
 }
 
@@ -926,8 +952,11 @@ optimize_swap() {
         chmod 600 /swapfile
         mkswap /swapfile >/dev/null 2>&1 || { log_warn "Ошибка mkswap"; return 1; }
         swapon /swapfile || { log_warn "Ошибка swapon"; return 1; }
-        # Добавляем в fstab если отсутствует
-        if ! grep -q '/swapfile' /etc/fstab; then
+        # Добавляем в fstab если отсутствует. Точная проверка по полям:
+        # игнорируем закомментированные строки и partial matches (например,
+        # `/swapfile.bak` или старая строка в комментарии).
+        if ! awk '!/^[[:space:]]*#/ && $1 == "/swapfile" && $3 == "swap" {found=1} END {exit !(found+0)}' \
+             /etc/fstab; then
             echo '/swapfile none swap sw 0 0' >> /etc/fstab
         fi
         log "Swap файл создан: ${target_swap_mb}MB"
@@ -1878,6 +1907,30 @@ step2_install_amnezia() {
             ;;
         *)
             ppa_codename="$codename"
+            # Для Ubuntu non-LTS (questing/plucky/oracular/...) PPA Amnezia
+            # пакетов не публикует — там 404 на dists/<codename>/Release.
+            # Проверяем доступность через HEAD-запрос и переключаемся на
+            # noble (LTS): сборка для noble корректно DKMS-собирается под
+            # текущее ядро.
+            # Связано: amnezia-vpn/amneziawg-linux-kernel-module#118
+            case "$ppa_codename" in
+                noble|jammy|focal)
+                    # Known LTS — пропускаем pre-check (PPA точно опубликован)
+                    ;;
+                *)
+                    log "Проверка доступности PPA Amnezia для Ubuntu '${ppa_codename}'..."
+                    if ! curl -fsI --max-time 15 --retry 2 --retry-delay 5 \
+                        "https://ppa.launchpadcontent.net/amnezia/ppa/ubuntu/dists/${ppa_codename}/Release" \
+                        >/dev/null 2>&1; then
+                        log_warn "PPA Amnezia не публикует пакеты для Ubuntu '${ppa_codename}' (HTTP 404 или host недоступен)."
+                        log_warn "Переключаюсь на 'noble' — DKMS соберёт модуль под текущее ядро."
+                        log_warn "Контекст: https://github.com/amnezia-vpn/amneziawg-linux-kernel-module/issues/118"
+                        ppa_codename="noble"
+                    else
+                        log "PPA Amnezia доступен для '${ppa_codename}'."
+                    fi
+                    ;;
+            esac
             ;;
     esac
 
@@ -1888,6 +1941,32 @@ step2_install_amnezia() {
     # Проверка на legacy-файлы (от add-apt-repository предыдущих версий)
     local legacy_list="/etc/apt/sources.list.d/amnezia-ubuntu-ppa-${codename}.list"
     local legacy_sources="/etc/apt/sources.list.d/amnezia-ubuntu-ppa-${codename}.sources"
+    # Повторный запуск на сервере, где предыдущий (≤ v5.12.1) создал .sources
+    # с «битым» Suites=questing/plucky/etc.: если найденный suite не совпадает
+    # с целевым ppa_codename — удаляем файл, чтобы пересоздать ниже с правильным.
+    # Та же проверка для устаревшего .sources (формат от add-apt-repository).
+    # Если файл существует, но строка `Suites:` не парсится — считаем повреждённым
+    # и тоже пересоздаём, иначе сломанный файл проскочит как «PPA уже добавлен».
+    local existing_suite=""
+    if [[ -f "$ppa_sources" ]]; then
+        existing_suite=$(awk '/^Suites:/{print $2; exit}' "$ppa_sources" 2>/dev/null)
+    fi
+    if [[ -f "$ppa_sources" && ( -z "$existing_suite" || "$existing_suite" != "$ppa_codename" ) ]]; then
+        if [[ -z "$existing_suite" ]]; then
+            log_warn "$ppa_sources существует, но строка Suites: не найдена — пересоздание."
+        else
+            log_warn "Существующий PPA suite='${existing_suite}', целевой='${ppa_codename}' — пересоздание $ppa_sources."
+        fi
+        rm -f "$ppa_sources" "$ppa_list"
+    fi
+    local legacy_suite=""
+    if [[ -f "$legacy_sources" ]]; then
+        legacy_suite=$(awk '/^Suites:/{print $2; exit}' "$legacy_sources" 2>/dev/null)
+    fi
+    if [[ -f "$legacy_sources" && ( -z "$legacy_suite" || "$legacy_suite" != "$ppa_codename" ) ]]; then
+        log_warn "Устаревший PPA-файл $legacy_sources (suite='${legacy_suite:-<пусто>}') не соответствует целевому '${ppa_codename}' — удаление."
+        rm -f "$legacy_sources" "$legacy_list"
+    fi
     if [[ -f "$legacy_list" ]] || [[ -f "$legacy_sources" ]]; then
         log "PPA уже добавлен (legacy-формат)."
     elif [[ -f "$ppa_sources" ]] || [[ -f "$ppa_list" ]]; then
@@ -2006,6 +2085,34 @@ PPASRC
             packages+=("$arch_pkg")
         else
             packages+=("linux-headers-generic")
+        fi
+    fi
+    # v5.13.0: на 25.10/26.04 после in-place upgrade с 24.04 в системе могут
+    # остаться kernel headers от 24.04 (6.8.x), скомпилированные gcc-13. В
+    # 25.10 по умолчанию ставится только gcc-15 → dkms autoinstall в postinst
+    # пакета amneziawg-dkms падает при сборке под устаревшие ядра, и dpkg
+    # оставляет amneziawg* unconfigured. Если в системе обнаружены kernel
+    # headers, отличные от running, заранее доставляем gcc-13 (доступен в
+    # questing/universe и 26.04 archive), чтобы autoinstall прошёл для всех
+    # ядер.
+    local _running_kernel _has_stale=0 _hd _hd_kern
+    _running_kernel="$(uname -r)"
+    for _hd in /lib/modules/*/build; do
+        [[ -e "$_hd" ]] || continue
+        _hd_kern="${_hd#/lib/modules/}"
+        _hd_kern="${_hd_kern%/build}"
+        if [[ "$_hd_kern" != "$_running_kernel" ]]; then
+            _has_stale=1
+            break
+        fi
+    done
+    if [[ "$_has_stale" -eq 1 ]] && ! command -v gcc-13 >/dev/null 2>&1; then
+        if apt-cache madison gcc-13 2>/dev/null | grep -q .; then
+            log "Обнаружены устаревшие kernel headers (≠ $_running_kernel) — устанавливаю gcc-13 для совместимости DKMS autoinstall."
+            DEBIAN_FRONTEND=noninteractive apt install -y gcc-13 \
+                || log_warn "Не удалось установить gcc-13 — DKMS autoinstall может падать на устаревших ядрах."
+        else
+            log_warn "Обнаружены устаревшие kernel headers, но gcc-13 недоступен в repo — DKMS autoinstall может падать."
         fi
     fi
     install_packages "${packages[@]}"
@@ -2633,6 +2740,28 @@ if [[ "$HELP" -eq 1 ]]; then show_help; fi
 if [[ "$UNINSTALL" -eq 1 ]]; then step_uninstall; fi
 if [[ "$DIAGNOSTIC" -eq 1 ]]; then create_diagnostic_report; exit 0; fi
 if [[ "$VERBOSE" -eq 1 ]]; then set -x; fi
+
+# v5.13.0: idempotency-страж — если AmneziaWG уже установлен и работает,
+# повторный запуск даром тратит ~20 минут (Step 1 ещё раз настраивает sysctl/swap/BBR,
+# `apt-get upgrade` может подтянуть новое ядро и заставить пользователя
+# заново перезагружаться, Step 7 рестартит awg-quick@awg0 — handshake
+# отваливаются на несколько секунд). Серверные ключи, пиры и параметры
+# обфускации сохраняются при повторе, но без явного opt-in это поведение
+# выглядит как «тихая переустановка». Защищаемся явным флагом.
+# Поднимает ENV AWG_FORCE_REINSTALL=1 ровно так же, как CLI-флаг.
+if [[ "${AWG_FORCE_REINSTALL:-0}" == "1" ]]; then
+    FORCE_REINSTALL=1
+fi
+if [[ "$FORCE_REINSTALL" -ne 1 ]] && [[ -f "$SERVER_CONF_FILE" ]] \
+   && systemctl is-active --quiet awg-quick@awg0 2>/dev/null; then
+    log_error "AmneziaWG уже установлен и запущен."
+    log_error "Чтобы переустановить — добавьте --force (или AWG_FORCE_REINSTALL=1)."
+    log_error "ВНИМАНИЕ: переустановка снова прогонит шаги 1 (sysctl/swap/BBR) и 7 (рестарт сервиса),"
+    log_error "          параметры обфускации (Jc/Jmin/Jmax/H1-H4/I1) сохранятся."
+    log_error "Для управления клиентами:  sudo bash $MANAGE_SCRIPT_PATH help"
+    log_error "Для полного удаления:      sudo bash $0 --uninstall"
+    exit 0
+fi
 
 initialize_setup
 

--- a/install_amneziawg_en.sh
+++ b/install_amneziawg_en.sh
@@ -8,14 +8,14 @@ fi
 # ==============================================================================
 # AmneziaWG 2.0 installation and configuration script for Ubuntu/Debian servers
 # Author: @bivlked
-# Version: 5.12.1
-# Date: 2026-05-08
+# Version: 5.13.0
+# Date: 2026-05-12
 # Repository: https://github.com/bivlked/amneziawg-installer
 # ==============================================================================
 
 # --- Safe mode and Constants ---
 set -o pipefail
-SCRIPT_VERSION="5.12.1"
+SCRIPT_VERSION="5.13.0"
 
 AWG_DIR="/root/awg"
 CONFIG_FILE="$AWG_DIR/awgsetup_cfg.init"
@@ -34,10 +34,11 @@ MANAGE_SCRIPT_PATH="$AWG_DIR/manage_amneziawg.sh"
 # Verification is skipped when AWG_BRANCH is overridden (test branch).
 # Format: sha256sum output (hex, 64 chars).
 COMMON_SCRIPT_SHA256="a788844e9097b373ed5a8cf1ea0e00965a8ccd1e187b607809a2dfe550ae1e62"
-MANAGE_SCRIPT_SHA256="24f64630a0384b8660e4587d8776309f0bb32db8be4281a5dedda0718f54f5f4"
+MANAGE_SCRIPT_SHA256="e030938342a6f2a26ca2060712ba13f23b84579346b410aa1c9641dedc010124"
 
 # CLI flags
 UNINSTALL=0; HELP=0; DIAGNOSTIC=0; VERBOSE=0; NO_COLOR=0; AUTO_YES=0; NO_TWEAKS=0
+FORCE_REINSTALL=0
 _APT_UPDATED=0
 CLI_PORT=""; CLI_SUBNET=""; CLI_DISABLE_IPV6="default"
 CLI_ROUTING_MODE="default"; CLI_CUSTOM_ROUTES=""; CLI_ENDPOINT=""; CLI_NO_TWEAKS=0
@@ -70,6 +71,7 @@ while [[ $# -gt 0 ]]; do
         --endpoint=*)    CLI_ENDPOINT="${1#*=}" ;;
         --yes|-y)        AUTO_YES=1 ;;
         --no-tweaks)     NO_TWEAKS=1; CLI_NO_TWEAKS=1 ;;
+        --force|-f)      FORCE_REINSTALL=1 ;;
         --preset=*)      CLI_PRESET="${1#*=}" ;;
         --jc=*)          CLI_JC="${1#*=}" ;;
         --jmin=*)        CLI_JMIN="${1#*=}" ;;
@@ -264,6 +266,9 @@ Options:
   --route-custom=NETS   Use 'Custom' mode non-interactively
   --endpoint=IP         Specify external server IP (for servers behind NAT)
   -y, --yes             Auto-confirm (reboots, UFW, etc.)
+  -f, --force           Force reinstall on top of an already-running AmneziaWG
+                        (by default a run on a configured server aborts;
+                        ENV: AWG_FORCE_REINSTALL=1 is equivalent to the flag)
   --no-tweaks           Skip hardening/optimization (no UFW, Fail2Ban, sysctl tweaks)
   --preset=TYPE         Obfuscation parameter preset: default, mobile
                         mobile: Jc=3, narrow Jmax — for mobile carriers (Tele2, Yota, Megafon)
@@ -451,7 +456,28 @@ install_packages() {
         apt_update_tolerant || log_warn "Failed to update apt."
         _APT_UPDATED=1
     fi
-    DEBIAN_FRONTEND=noninteractive apt install -y "${to_install[@]}" || die "Package installation error."
+    if ! DEBIAN_FRONTEND=noninteractive apt install -y "${to_install[@]}"; then
+        # v5.13.0: typical failure on 25.10/26.04 after an in-place upgrade
+        # from 24.04 — the amneziawg-dkms postinst runs `dkms autoinstall`
+        # which iterates over ALL kernels in /lib/modules/. The leftover
+        # 6.8.x headers were compiled with gcc-13, but 25.10 ships only
+        # gcc-15 by default → autoinstall fails, dpkg leaves the dependent
+        # amneziawg-tools / amneziawg unconfigured. Force-build the module
+        # for the running kernel only and finish with dpkg --configure -a.
+        if printf '%s\n' "${to_install[@]}" | grep -qx "amneziawg-dkms"; then
+            log_warn "apt install did not complete — trying a DKMS build for the running kernel $(uname -r) only..."
+            local _mver
+            _mver="$(ls /var/lib/dkms/amneziawg/ 2>/dev/null | head -n1)"
+            if [[ -n "$_mver" ]] \
+               && dkms install -m amneziawg -v "$_mver" -k "$(uname -r)" --force \
+               && DEBIAN_FRONTEND=noninteractive dpkg --configure -a; then
+                log "DKMS module built for $(uname -r), dpkg configured."
+                log "Packages installed."
+                return 0
+            fi
+        fi
+        die "Package installation error."
+    fi
     log "Packages installed."
 }
 
@@ -930,8 +956,11 @@ optimize_swap() {
         chmod 600 /swapfile
         mkswap /swapfile >/dev/null 2>&1 || { log_warn "mkswap error"; return 1; }
         swapon /swapfile || { log_warn "swapon error"; return 1; }
-        # Add to fstab if missing
-        if ! grep -q '/swapfile' /etc/fstab; then
+        # Add to fstab if missing. Precise field match: ignore commented
+        # lines and partial matches (e.g. `/swapfile.bak` or an old entry
+        # left in a comment).
+        if ! awk '!/^[[:space:]]*#/ && $1 == "/swapfile" && $3 == "swap" {found=1} END {exit !(found+0)}' \
+             /etc/fstab; then
             echo '/swapfile none swap sw 0 0' >> /etc/fstab
         fi
         log "Swap file created: ${target_swap_mb}MB"
@@ -1892,6 +1921,29 @@ step2_install_amnezia() {
             ;;
         *)
             ppa_codename="$codename"
+            # For Ubuntu non-LTS (questing/plucky/oracular/...) Amnezia PPA does
+            # not publish packages — dists/<codename>/Release returns 404.
+            # Pre-check via HEAD and fall back to noble (LTS): the noble build
+            # gets DKMS-compiled against the running kernel.
+            # Upstream: amnezia-vpn/amneziawg-linux-kernel-module#118
+            case "$ppa_codename" in
+                noble|jammy|focal)
+                    # Known LTS — skip pre-check (PPA is reliably published)
+                    ;;
+                *)
+                    log "Checking Amnezia PPA availability for Ubuntu '${ppa_codename}'..."
+                    if ! curl -fsI --max-time 15 --retry 2 --retry-delay 5 \
+                        "https://ppa.launchpadcontent.net/amnezia/ppa/ubuntu/dists/${ppa_codename}/Release" \
+                        >/dev/null 2>&1; then
+                        log_warn "Amnezia PPA does not publish packages for Ubuntu '${ppa_codename}' (HTTP 404 or host unreachable)."
+                        log_warn "Falling back to 'noble' — DKMS will build the module against the running kernel."
+                        log_warn "Context: https://github.com/amnezia-vpn/amneziawg-linux-kernel-module/issues/118"
+                        ppa_codename="noble"
+                    else
+                        log "Amnezia PPA is available for '${ppa_codename}'."
+                    fi
+                    ;;
+            esac
             ;;
     esac
 
@@ -1902,6 +1954,34 @@ step2_install_amnezia() {
     # Check for legacy files (from add-apt-repository of previous versions)
     local legacy_list="/etc/apt/sources.list.d/amnezia-ubuntu-ppa-${codename}.list"
     local legacy_sources="/etc/apt/sources.list.d/amnezia-ubuntu-ppa-${codename}.sources"
+    # Re-run on a server where a previous run (≤ v5.12.1) wrote a broken
+    # .sources file with Suites=questing/plucky/etc.: if the existing suite
+    # doesn't match the target ppa_codename, remove the file so it gets
+    # recreated below with the correct suite. Same check for legacy
+    # .sources (add-apt-repository format).
+    # If the file exists but `Suites:` can't be parsed — treat as corrupt
+    # and recreate, otherwise the broken file would slip through as
+    # "PPA already added".
+    local existing_suite=""
+    if [[ -f "$ppa_sources" ]]; then
+        existing_suite=$(awk '/^Suites:/{print $2; exit}' "$ppa_sources" 2>/dev/null)
+    fi
+    if [[ -f "$ppa_sources" && ( -z "$existing_suite" || "$existing_suite" != "$ppa_codename" ) ]]; then
+        if [[ -z "$existing_suite" ]]; then
+            log_warn "$ppa_sources exists but no Suites: line found — recreating."
+        else
+            log_warn "Existing PPA suite='${existing_suite}', target='${ppa_codename}' — recreating $ppa_sources."
+        fi
+        rm -f "$ppa_sources" "$ppa_list"
+    fi
+    local legacy_suite=""
+    if [[ -f "$legacy_sources" ]]; then
+        legacy_suite=$(awk '/^Suites:/{print $2; exit}' "$legacy_sources" 2>/dev/null)
+    fi
+    if [[ -f "$legacy_sources" && ( -z "$legacy_suite" || "$legacy_suite" != "$ppa_codename" ) ]]; then
+        log_warn "Legacy PPA $legacy_sources (suite='${legacy_suite:-<empty>}') does not match target '${ppa_codename}' — removing."
+        rm -f "$legacy_sources" "$legacy_list"
+    fi
     if [[ -f "$legacy_list" ]] || [[ -f "$legacy_sources" ]]; then
         log "PPA already added (legacy format)."
     elif [[ -f "$ppa_sources" ]] || [[ -f "$ppa_list" ]]; then
@@ -2020,6 +2100,34 @@ PPASRC
             packages+=("$arch_pkg")
         else
             packages+=("linux-headers-generic")
+        fi
+    fi
+    # v5.13.0: on 25.10/26.04 after an in-place upgrade from 24.04, the
+    # system may still carry kernel headers from 24.04 (6.8.x) compiled with
+    # gcc-13. 25.10 ships gcc-15 by default → dkms autoinstall in the
+    # amneziawg-dkms postinst fails when building against stale kernels, and
+    # dpkg leaves amneziawg* unconfigured. If we detect kernel headers other
+    # than the running one, install gcc-13 ahead of time (available in
+    # questing/universe and 26.04 archive) so autoinstall succeeds for every
+    # kernel.
+    local _running_kernel _has_stale=0 _hd _hd_kern
+    _running_kernel="$(uname -r)"
+    for _hd in /lib/modules/*/build; do
+        [[ -e "$_hd" ]] || continue
+        _hd_kern="${_hd#/lib/modules/}"
+        _hd_kern="${_hd_kern%/build}"
+        if [[ "$_hd_kern" != "$_running_kernel" ]]; then
+            _has_stale=1
+            break
+        fi
+    done
+    if [[ "$_has_stale" -eq 1 ]] && ! command -v gcc-13 >/dev/null 2>&1; then
+        if apt-cache madison gcc-13 2>/dev/null | grep -q .; then
+            log "Stale kernel headers detected (other than $_running_kernel) — installing gcc-13 for DKMS autoinstall compatibility."
+            DEBIAN_FRONTEND=noninteractive apt install -y gcc-13 \
+                || log_warn "gcc-13 install failed — DKMS autoinstall may fail on stale kernels."
+        else
+            log_warn "Stale kernel headers detected, but gcc-13 is not in the repo — DKMS autoinstall may fail."
         fi
     fi
     install_packages "${packages[@]}"
@@ -2648,6 +2756,28 @@ if [[ "$HELP" -eq 1 ]]; then show_help; fi
 if [[ "$UNINSTALL" -eq 1 ]]; then step_uninstall; fi
 if [[ "$DIAGNOSTIC" -eq 1 ]]; then create_diagnostic_report; exit 0; fi
 if [[ "$VERBOSE" -eq 1 ]]; then set -x; fi
+
+# v5.13.0: idempotency guard — if AmneziaWG is already installed and
+# running, a re-run wastes ~20 minutes (Step 1 re-tunes sysctl/swap/BBR,
+# `apt-get upgrade` can pull a new kernel and force another reboot, Step 7
+# restarts awg-quick@awg0 — handshakes drop for a few seconds). Server
+# keys, peers and obfuscation parameters survive a re-run, but without
+# explicit opt-in this behaviour looks like a silent reinstall. Guarded by
+# an explicit flag.
+# AWG_FORCE_REINSTALL=1 in the environment is equivalent to --force.
+if [[ "${AWG_FORCE_REINSTALL:-0}" == "1" ]]; then
+    FORCE_REINSTALL=1
+fi
+if [[ "$FORCE_REINSTALL" -ne 1 ]] && [[ -f "$SERVER_CONF_FILE" ]] \
+   && systemctl is-active --quiet awg-quick@awg0 2>/dev/null; then
+    log_error "AmneziaWG is already installed and running."
+    log_error "To reinstall — pass --force (or AWG_FORCE_REINSTALL=1)."
+    log_error "WARNING: a reinstall will rerun Step 1 (sysctl/swap/BBR) and Step 7 (service restart);"
+    log_error "         obfuscation parameters (Jc/Jmin/Jmax/H1-H4/I1) survive."
+    log_error "To manage clients:  sudo bash $MANAGE_SCRIPT_PATH help"
+    log_error "To fully uninstall: sudo bash $0 --uninstall"
+    exit 0
+fi
 
 initialize_setup
 

--- a/manage_amneziawg.sh
+++ b/manage_amneziawg.sh
@@ -8,14 +8,14 @@ fi
 # ==============================================================================
 # Скрипт для управления пользователями (пирами) AmneziaWG 2.0
 # Автор: @bivlked
-# Версия: 5.12.1
-# Дата: 2026-05-08
+# Версия: 5.13.0
+# Дата: 2026-05-12
 # Репозиторий: https://github.com/bivlked/amneziawg-installer
 # ==============================================================================
 
 # --- Безопасный режим и Константы ---
 # shellcheck disable=SC2034
-SCRIPT_VERSION="5.12.1"
+SCRIPT_VERSION="5.13.0"
 set -o pipefail
 AWG_DIR="/root/awg"
 SERVER_CONF_FILE="/etc/amnezia/amneziawg/awg0.conf"
@@ -115,7 +115,9 @@ log_msg() {
         echo "[$ts] ERROR: Ошибка записи лога $LOG_FILE" >&2
     fi
 
-    if [[ "$type" == "ERROR" ]]; then
+    # WARN и ERROR в stderr (симметрия с install_amneziawg.sh:110+, важно
+    # для CI/automation парсинга: stdout = «данные», stderr = «диагностика»).
+    if [[ "$type" == "ERROR" || "$type" == "WARN" ]]; then
         printf "${color_start}%s${color_end}\n" "$entry" >&2
     else
         printf "${color_start}%s${color_end}\n" "$entry"

--- a/manage_amneziawg_en.sh
+++ b/manage_amneziawg_en.sh
@@ -8,14 +8,14 @@ fi
 # ==============================================================================
 # AmneziaWG 2.0 peer management script
 # Author: @bivlked
-# Version: 5.12.1
-# Date: 2026-05-08
+# Version: 5.13.0
+# Date: 2026-05-12
 # Repository: https://github.com/bivlked/amneziawg-installer
 # ==============================================================================
 
 # --- Safe mode and Constants ---
 # shellcheck disable=SC2034
-SCRIPT_VERSION="5.12.1"
+SCRIPT_VERSION="5.13.0"
 set -o pipefail
 AWG_DIR="/root/awg"
 SERVER_CONF_FILE="/etc/amnezia/amneziawg/awg0.conf"
@@ -115,7 +115,9 @@ log_msg() {
         echo "[$ts] ERROR: Log write error $LOG_FILE" >&2
     fi
 
-    if [[ "$type" == "ERROR" ]]; then
+    # WARN and ERROR go to stderr (symmetry with install_amneziawg.sh:110+,
+    # important for CI/automation parsing: stdout = "data", stderr = "diagnostics").
+    if [[ "$type" == "ERROR" || "$type" == "WARN" ]]; then
         printf "${color_start}%s${color_end}\n" "$entry" >&2
     else
         printf "${color_start}%s${color_end}\n" "$entry"

--- a/tests/test_v5115_regen_multiarg.bats
+++ b/tests/test_v5115_regen_multiarg.bats
@@ -113,11 +113,14 @@
 
 # ---------- Version markers ----------
 
-@test "v5.12.1: SCRIPT_VERSION bumped in all six files" {
+@test "v5.13.0: SCRIPT_VERSION bumped in installer + manage scripts" {
+    # install_amneziawg.sh, install_amneziawg_en.sh, manage_amneziawg.sh,
+    # manage_amneziawg_en.sh: all four were modified in v5.13.0 → version bumped.
     for f in install_amneziawg.sh install_amneziawg_en.sh manage_amneziawg.sh manage_amneziawg_en.sh; do
-        run grep -E 'SCRIPT_VERSION="5\.12\.1"' "$BATS_TEST_DIRNAME/../$f"
+        run grep -E 'SCRIPT_VERSION="5\.13\.0"' "$BATS_TEST_DIRNAME/../$f"
         [ "$status" -eq 0 ]
     done
+    # awg_common.sh + _en.sh were NOT modified in v5.13.0 → version stays at 5.12.1.
     run grep -E '# Версия: 5\.12\.1' "$BATS_TEST_DIRNAME/../awg_common.sh"
     [ "$status" -eq 0 ]
     run grep -E '# Version: 5\.12\.1' "$BATS_TEST_DIRNAME/../awg_common_en.sh"

--- a/tests/test_v5130_bundled_fixes.bats
+++ b/tests/test_v5130_bundled_fixes.bats
@@ -1,0 +1,186 @@
+#!/usr/bin/env bats
+# v5.13.0 bundled robustness fixes (rolled in alongside PPA noble fallback):
+#
+# 1. MyAI-rcgr — manage_amneziawg.sh log_msg now routes WARN to stderr
+#    (matching install_amneziawg.sh:110+). Until v5.12.1, manage sent only
+#    ERROR to stderr and dropped WARN into stdout, which broke CI/automation
+#    that captured stdout for data only.
+#
+# 2. MyAI-i31a — install_amneziawg.sh optimize_swap now uses a field-aware
+#    awk check on /etc/fstab instead of a substring grep. The old
+#    `grep -q '/swapfile' /etc/fstab` matched commented lines and partial
+#    names (e.g. `/swapfile.bak`), which on a re-run could skip adding a
+#    valid entry — swap then wouldn't mount on reboot.
+
+# ===========================================================================
+# rcgr: manage log_msg routes WARN to stderr (RU + EN)
+# ===========================================================================
+
+@test "v5.13.0 rcgr: RU manage log_msg routes WARN to stderr" {
+    block=$(awk '/^log_msg\(\) \{/,/^\}/' \
+        "$BATS_TEST_DIRNAME/../manage_amneziawg.sh")
+    [[ "$block" == *'"$type" == "ERROR" || "$type" == "WARN"'* ]]
+    # The body that goes to stderr must be the same printf with >&2 redirect.
+    [[ "$block" == *'>&2'* ]]
+}
+
+@test "v5.13.0 rcgr: EN manage log_msg routes WARN to stderr" {
+    block=$(awk '/^log_msg\(\) \{/,/^\}/' \
+        "$BATS_TEST_DIRNAME/../manage_amneziawg_en.sh")
+    [[ "$block" == *'"$type" == "ERROR" || "$type" == "WARN"'* ]]
+    [[ "$block" == *'>&2'* ]]
+}
+
+@test "v5.13.0 rcgr: RU and EN manage log_msg are in sync" {
+    ru=$(awk '/^log_msg\(\) \{/,/^\}/' \
+        "$BATS_TEST_DIRNAME/../manage_amneziawg.sh" \
+        | grep -c '"$type" == "ERROR" || "$type" == "WARN"')
+    en=$(awk '/^log_msg\(\) \{/,/^\}/' \
+        "$BATS_TEST_DIRNAME/../manage_amneziawg_en.sh" \
+        | grep -c '"$type" == "ERROR" || "$type" == "WARN"')
+    [ "$ru" -eq 1 ]
+    [ "$en" -eq 1 ]
+}
+
+@test "v5.13.0 rcgr: manage log_msg now matches install log_msg behaviour" {
+    # install_amneziawg.sh already routed WARN to stderr (line ~110).
+    # manage must now do the same for consistency.
+    install_block=$(awk '/^log_msg\(\) \{/,/^\}/' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh")
+    manage_block=$(awk '/^log_msg\(\) \{/,/^\}/' \
+        "$BATS_TEST_DIRNAME/../manage_amneziawg.sh")
+    [[ "$install_block" == *'WARN'*'>&2'* ]] || [[ "$install_block" == *'"$type" == "ERROR" || "$type" == "WARN"'* ]]
+    [[ "$manage_block" == *'WARN'*'>&2'* ]] || [[ "$manage_block" == *'"$type" == "ERROR" || "$type" == "WARN"'* ]]
+}
+
+# ---- functional: simulate log_msg WARN goes to stderr ----
+
+# Replicate the v5.13.0 manage log_msg branch (no $LOG_FILE side effect).
+run_warn_routed() {
+    local type="$1" msg="$2"
+    local entry="[ts] $type: $msg"
+    if [[ "$type" == "ERROR" || "$type" == "WARN" ]]; then
+        printf '%s\n' "$entry" >&2
+    else
+        printf '%s\n' "$entry"
+    fi
+}
+
+@test "v5.13.0 rcgr functional: WARN goes to stderr, not stdout" {
+    out=$(run_warn_routed WARN "test warning" 2>/dev/null)
+    err=$(run_warn_routed WARN "test warning" 2>&1 1>/dev/null)
+    [ -z "$out" ]
+    [[ "$err" == *"WARN: test warning"* ]]
+}
+
+@test "v5.13.0 rcgr functional: ERROR still goes to stderr" {
+    out=$(run_warn_routed ERROR "test error" 2>/dev/null)
+    err=$(run_warn_routed ERROR "test error" 2>&1 1>/dev/null)
+    [ -z "$out" ]
+    [[ "$err" == *"ERROR: test error"* ]]
+}
+
+@test "v5.13.0 rcgr functional: INFO still goes to stdout" {
+    out=$(run_warn_routed INFO "test info" 2>/dev/null)
+    err=$(run_warn_routed INFO "test info" 2>&1 1>/dev/null)
+    [[ "$out" == *"INFO: test info"* ]]
+    [ -z "$err" ]
+}
+
+# ===========================================================================
+# i31a: install fstab swap check uses awk field-match (RU + EN)
+# ===========================================================================
+
+@test "v5.13.0 i31a: RU install uses awk field check for /swapfile in fstab" {
+    grep -q "awk '!/\^\[\[:space:\]\]\*#/ && \\\$1 == \"/swapfile\" && \\\$3 == \"swap\"" \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh"
+    # Old substring grep must be gone.
+    ! grep -q "grep -q '/swapfile' /etc/fstab" \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh"
+}
+
+@test "v5.13.0 i31a: EN install uses awk field check for /swapfile in fstab" {
+    grep -q "awk '!/\^\[\[:space:\]\]\*#/ && \\\$1 == \"/swapfile\" && \\\$3 == \"swap\"" \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh"
+    ! grep -q "grep -q '/swapfile' /etc/fstab" \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh"
+}
+
+# ---- functional: simulate the awk check on various fstab contents ----
+
+check_fstab_has_swap() {
+    awk '!/^[[:space:]]*#/ && $1 == "/swapfile" && $3 == "swap" {found=1} END {exit !(found+0)}' "$1"
+}
+
+@test "v5.13.0 i31a: valid /swapfile entry detected (returns 0)" {
+    tmp=$(mktemp)
+    cat > "$tmp" <<EOF
+UUID=abc-123 / ext4 defaults 0 1
+/swapfile none swap sw 0 0
+EOF
+    check_fstab_has_swap "$tmp"
+    rm -f "$tmp"
+}
+
+@test "v5.13.0 i31a: commented /swapfile NOT detected (returns 1)" {
+    tmp=$(mktemp)
+    cat > "$tmp" <<EOF
+UUID=abc-123 / ext4 defaults 0 1
+# Old entry: /swapfile none swap sw 0 0
+EOF
+    run check_fstab_has_swap "$tmp"
+    [ "$status" -ne 0 ]
+    rm -f "$tmp"
+}
+
+@test "v5.13.0 i31a: partial name /swapfile.bak NOT detected (returns 1)" {
+    tmp=$(mktemp)
+    cat > "$tmp" <<EOF
+UUID=abc-123 / ext4 defaults 0 1
+/swapfile.bak none swap sw 0 0
+EOF
+    run check_fstab_has_swap "$tmp"
+    [ "$status" -ne 0 ]
+    rm -f "$tmp"
+}
+
+@test "v5.13.0 i31a: indented /swapfile entry still detected" {
+    tmp=$(mktemp)
+    cat > "$tmp" <<EOF
+UUID=abc-123 / ext4 defaults 0 1
+   /swapfile none swap sw 0 0
+EOF
+    check_fstab_has_swap "$tmp"
+    rm -f "$tmp"
+}
+
+@test "v5.13.0 i31a: indented comment NOT confusing the parser" {
+    tmp=$(mktemp)
+    cat > "$tmp" <<EOF
+UUID=abc-123 / ext4 defaults 0 1
+   # /swapfile none swap sw 0 0
+EOF
+    run check_fstab_has_swap "$tmp"
+    [ "$status" -ne 0 ]
+    rm -f "$tmp"
+}
+
+@test "v5.13.0 i31a: empty fstab returns 1 (no entry)" {
+    tmp=$(mktemp)
+    : > "$tmp"
+    run check_fstab_has_swap "$tmp"
+    [ "$status" -ne 0 ]
+    rm -f "$tmp"
+}
+
+@test "v5.13.0 i31a: /swapfile with wrong type (not swap) NOT detected" {
+    # Edge: someone has a file at /swapfile mounted as ext4 binding. Our
+    # check requires $3 == "swap" so this should not match.
+    tmp=$(mktemp)
+    cat > "$tmp" <<EOF
+/swapfile /mnt/foo ext4 defaults 0 0
+EOF
+    run check_fstab_has_swap "$tmp"
+    [ "$status" -ne 0 ]
+    rm -f "$tmp"
+}

--- a/tests/test_v5130_force_guard.bats
+++ b/tests/test_v5130_force_guard.bats
@@ -1,0 +1,161 @@
+#!/usr/bin/env bats
+# v5.13.0 idempotency / --force safety guard (MyAI-cq9g, Issue #78).
+#
+# Background: re-running the installer on a configured server silently
+# repeats Step 1 (sysctl/swap/BBR, possible kernel upgrade + reboot loop)
+# and Step 7 (service restart, drops live handshakes). Server keys,
+# peers, and obfuscation parameters survive a re-run, but the user
+# expects an upfront "already installed" message.
+#
+# v5.13.0 fix: idempotency guard at the start of the main loop —
+# checks $SERVER_CONF_FILE existence + awg-quick@awg0 active, and aborts
+# unless --force / AWG_FORCE_REINSTALL=1 is set.
+
+# ---------- structural: RU script ----------
+
+@test "v5.13.0: RU install has --force flag in CLI parser" {
+    grep -qE '\-\-force\|-f\).*FORCE_REINSTALL=1' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh"
+}
+
+@test "v5.13.0: RU install initializes FORCE_REINSTALL=0" {
+    grep -qE '^FORCE_REINSTALL=0\b' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh"
+}
+
+@test "v5.13.0: RU install reads AWG_FORCE_REINSTALL from env" {
+    grep -q 'AWG_FORCE_REINSTALL:-0' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh"
+}
+
+@test "v5.13.0: RU install guard checks SERVER_CONF_FILE + service active" {
+    grep -q '\-f "\$SERVER_CONF_FILE"' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh"
+    grep -q 'systemctl is-active --quiet awg-quick@awg0' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh"
+}
+
+@test "v5.13.0: RU install guard message mentions --force flag and ENV" {
+    grep -q 'AmneziaWG уже установлен и запущен' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh"
+    grep -q 'AWG_FORCE_REINSTALL=1' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh"
+}
+
+@test "v5.13.0: RU install help mentions --force" {
+    grep -q -- '-f, --force' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh"
+}
+
+# ---------- structural: EN script ----------
+
+@test "v5.13.0: EN install has --force flag in CLI parser" {
+    grep -qE '\-\-force\|-f\).*FORCE_REINSTALL=1' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh"
+}
+
+@test "v5.13.0: EN install initializes FORCE_REINSTALL=0" {
+    grep -qE '^FORCE_REINSTALL=0\b' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh"
+}
+
+@test "v5.13.0: EN install reads AWG_FORCE_REINSTALL from env" {
+    grep -q 'AWG_FORCE_REINSTALL:-0' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh"
+}
+
+@test "v5.13.0: EN install guard checks SERVER_CONF_FILE + service active" {
+    grep -q '\-f "\$SERVER_CONF_FILE"' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh"
+    grep -q 'systemctl is-active --quiet awg-quick@awg0' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh"
+}
+
+@test "v5.13.0: EN install guard message is in English and mentions --force" {
+    grep -q 'AmneziaWG is already installed and running' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh"
+    grep -q 'AWG_FORCE_REINSTALL=1' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh"
+}
+
+@test "v5.13.0: EN install help mentions --force" {
+    grep -q -- '-f, --force' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh"
+}
+
+# ---------- functional: guard decision matrix ----------
+
+# Helper: replicate the v5.13.0 guard. Returns 0 if installer should
+# proceed (and lets the caller run install), or echoes "skip" and
+# returns 1 if the guard would abort.
+run_guard() {
+    local SERVER_CONF_FILE="$1"
+    local SERVICE_ACTIVE="$2"   # 0/1
+    local FORCE_REINSTALL="$3"  # 0/1
+    local AWG_FORCE_REINSTALL="${4:-0}"
+
+    # Emulate the env-var → flag bridge
+    if [[ "$AWG_FORCE_REINSTALL" == "1" ]]; then
+        FORCE_REINSTALL=1
+    fi
+
+    if [[ "$FORCE_REINSTALL" -ne 1 ]] && [[ -f "$SERVER_CONF_FILE" ]] \
+       && [[ "$SERVICE_ACTIVE" == "1" ]]; then
+        echo "skip"
+        return 1
+    fi
+    echo "proceed"
+    return 0
+}
+
+@test "v5.13.0 cq9g: clean install (no conf, no service) => proceed" {
+    result=$(run_guard "/tmp/does-not-exist" 0 0 0)
+    [ "$result" = "proceed" ]
+}
+
+@test "v5.13.0 cq9g: configured + active + no force => skip" {
+    tmp=$(mktemp)
+    result=$(run_guard "$tmp" 1 0 0) || true
+    [ "$result" = "skip" ]
+    rm -f "$tmp"
+}
+
+@test "v5.13.0 cq9g: configured + inactive (broken) + no force => proceed (repair flow)" {
+    tmp=$(mktemp)
+    result=$(run_guard "$tmp" 0 0 0)
+    [ "$result" = "proceed" ]
+    rm -f "$tmp"
+}
+
+@test "v5.13.0 cq9g: configured + active + --force => proceed" {
+    tmp=$(mktemp)
+    result=$(run_guard "$tmp" 1 1 0)
+    [ "$result" = "proceed" ]
+    rm -f "$tmp"
+}
+
+@test "v5.13.0 cq9g: configured + active + AWG_FORCE_REINSTALL=1 env => proceed" {
+    tmp=$(mktemp)
+    result=$(run_guard "$tmp" 1 0 1)
+    [ "$result" = "proceed" ]
+    rm -f "$tmp"
+}
+
+@test "v5.13.0 cq9g: AWG_FORCE_REINSTALL=yes (non-1) is NOT honoured (only =1)" {
+    tmp=$(mktemp)
+    result=$(run_guard "$tmp" 1 0 yes) || true
+    # Strict =1 check — "yes" should not bypass
+    [ "$result" = "skip" ]
+    rm -f "$tmp"
+}
+
+# ---------- structural parity ----------
+
+@test "v5.13.0: RU/EN install guard structure has parity" {
+    ru_count=$(grep -c 'FORCE_REINSTALL' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh")
+    en_count=$(grep -c 'FORCE_REINSTALL' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh")
+    [ "$ru_count" -eq "$en_count" ]
+    [ "$ru_count" -ge 4 ]   # init + CLI flag + env bridge + guard
+}

--- a/tests/test_v5130_ppa_noble_fallback.bats
+++ b/tests/test_v5130_ppa_noble_fallback.bats
@@ -1,0 +1,425 @@
+#!/usr/bin/env bats
+# v5.13.0 PPA noble fallback for Ubuntu non-LTS releases.
+#
+# Background: PPA Amnezia (ppa:amnezia/ppa on Launchpad) publishes packages
+# only for known LTS Ubuntu codenames (noble/jammy/focal). Interim releases
+# (questing/plucky/oracular/...) hit a 404 on dists/<codename>/Release.
+# Upstream: amnezia-vpn/amneziawg-linux-kernel-module#118
+#
+# v5.13.0 fix: pre-check PPA availability with `curl -fsI`. On 404 or host
+# unreachable, fall back to 'noble' (LTS) — DKMS builds the module against
+# the running kernel.
+#
+# Also handles re-run: a previous (≤ v5.12.1) install on questing wrote
+# /etc/apt/sources.list.d/amnezia-ppa.sources with `Suites: questing`. On
+# the next run, suite-mismatch detection rewrites it with the correct value.
+
+# ---------- structural: RU script contains pre-check ----------
+
+@test "v5.13.0: RU install has PPA pre-check for Ubuntu non-LTS" {
+    grep -q 'Проверка доступности PPA Amnezia для Ubuntu' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh"
+    grep -q 'curl -fsI --max-time 15 --retry 2 --retry-delay 5' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh"
+    grep -q 'dists/${ppa_codename}/Release' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh"
+}
+
+@test "v5.13.0: RU install whitelists LTS codenames (noble|jammy|focal)" {
+    grep -q 'noble|jammy|focal)' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh"
+}
+
+@test "v5.13.0: RU install falls back ppa_codename to noble on failure" {
+    block=$(awk '/Проверка доступности PPA Amnezia для Ubuntu/,/log "PPA Amnezia доступен/' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh")
+    [[ "$block" == *'ppa_codename="noble"'* ]]
+    [[ "$block" == *'kernel-module/issues/118'* ]]
+}
+
+@test "v5.13.0: RU install has suite-mismatch detection" {
+    grep -q "awk '/\^Suites:/{print \$2; exit}'" \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh"
+    grep -q 'пересоздание' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh"
+}
+
+@test "v5.13.0: RU install handles corrupt .sources (no Suites line)" {
+    grep -q 'строка Suites: не найдена' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh"
+}
+
+@test "v5.13.0: RU install also checks legacy .sources for suite mismatch" {
+    grep -q 'legacy_suite' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh"
+    grep -q 'Устаревший PPA-файл' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh"
+}
+
+@test "v5.13.0: RU install_packages falls back to dkms install for running kernel on amneziawg-dkms failure" {
+    block=$(awk '/^install_packages\(\) \{/,/^\}/' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh")
+    [[ "$block" == *'amneziawg-dkms'* ]]
+    [[ "$block" == *'dkms install -m amneziawg'* ]]
+    [[ "$block" == *'-k "$(uname -r)" --force'* ]]
+    [[ "$block" == *'dpkg --configure -a'* ]]
+}
+
+@test "v5.13.0: EN install_packages falls back to dkms install for running kernel on amneziawg-dkms failure" {
+    block=$(awk '/^install_packages\(\) \{/,/^\}/' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh")
+    [[ "$block" == *'amneziawg-dkms'* ]]
+    [[ "$block" == *'dkms install -m amneziawg'* ]]
+    [[ "$block" == *'-k "$(uname -r)" --force'* ]]
+    [[ "$block" == *'dpkg --configure -a'* ]]
+}
+
+@test "v5.13.0: RU install pre-installs gcc-13 when stale kernel headers detected" {
+    grep -q 'устаревшие kernel headers' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh"
+    grep -q 'apt-cache madison gcc-13' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh"
+    grep -q 'apt install -y gcc-13' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh"
+}
+
+@test "v5.13.0: EN install pre-installs gcc-13 when stale kernel headers detected" {
+    grep -q 'Stale kernel headers detected' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh"
+    grep -q 'apt-cache madison gcc-13' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh"
+    grep -q 'apt install -y gcc-13' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh"
+}
+
+# ---- functional: stale-kernel-headers detection loop logic ----
+
+@test "v5.13.0: stale detection - only running kernel => no stale" {
+    tmpdir=$(mktemp -d)/lib/modules
+    mkdir -p "$tmpdir/6.17.0-23-generic/build"
+    running="6.17.0-23-generic"
+    has_stale=0
+    for hd in "$tmpdir"/*/build; do
+        [[ -e "$hd" ]] || continue
+        hd_kern="${hd#$tmpdir/}"
+        hd_kern="${hd_kern%/build}"
+        if [[ "$hd_kern" != "$running" ]]; then
+            has_stale=1
+            break
+        fi
+    done
+    [ "$has_stale" -eq 0 ]
+    rm -rf "$(dirname "$tmpdir")"
+}
+
+@test "v5.13.0: stale detection - running + 6.8 => stale=1" {
+    tmpdir=$(mktemp -d)/lib/modules
+    mkdir -p "$tmpdir/6.17.0-23-generic/build" "$tmpdir/6.8.0-111-generic/build"
+    running="6.17.0-23-generic"
+    has_stale=0
+    for hd in "$tmpdir"/*/build; do
+        [[ -e "$hd" ]] || continue
+        hd_kern="${hd#$tmpdir/}"
+        hd_kern="${hd_kern%/build}"
+        if [[ "$hd_kern" != "$running" ]]; then
+            has_stale=1
+            break
+        fi
+    done
+    [ "$has_stale" -eq 1 ]
+    rm -rf "$(dirname "$tmpdir")"
+}
+
+# ---------- structural: EN script mirror ----------
+
+@test "v5.13.0: EN install has PPA pre-check for Ubuntu non-LTS" {
+    grep -q 'Checking Amnezia PPA availability for Ubuntu' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh"
+    grep -q 'curl -fsI --max-time 15 --retry 2 --retry-delay 5' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh"
+    grep -q 'dists/${ppa_codename}/Release' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh"
+}
+
+@test "v5.13.0: EN install whitelists LTS codenames (noble|jammy|focal)" {
+    grep -q 'noble|jammy|focal)' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh"
+}
+
+@test "v5.13.0: EN install falls back ppa_codename to noble on failure" {
+    block=$(awk '/Checking Amnezia PPA availability for Ubuntu/,/log "Amnezia PPA is available/' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh")
+    [[ "$block" == *'ppa_codename="noble"'* ]]
+    [[ "$block" == *'kernel-module/issues/118'* ]]
+}
+
+@test "v5.13.0: EN install has suite-mismatch detection" {
+    grep -q "awk '/\^Suites:/{print \$2; exit}'" \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh"
+    grep -q 'recreating' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh"
+}
+
+@test "v5.13.0: EN install handles corrupt .sources (no Suites line)" {
+    grep -q 'no Suites: line found' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh"
+}
+
+@test "v5.13.0: EN install also checks legacy .sources for suite mismatch" {
+    grep -q 'legacy_suite' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh"
+    grep -q 'Legacy PPA' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh"
+}
+
+# ---------- structural: parity counts ----------
+
+@test "v5.13.0: RU/EN pre-check block parity (curl line count matches)" {
+    ru=$(grep -c 'curl -fsI --max-time 15 --retry 2 --retry-delay 5' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh")
+    en=$(grep -c 'curl -fsI --max-time 15 --retry 2 --retry-delay 5' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh")
+    [ "$ru" -eq "$en" ]
+    [ "$ru" -eq 1 ]
+}
+
+@test "v5.13.0: RU/EN noble fallback assignment count matches" {
+    # Both scripts must assign ppa_codename="noble" inside the pre-check
+    # exactly once. (Other "noble" mentions exist in Debian mapping above.)
+    ru_pre=$(awk '/case "\$ppa_codename" in/,/^            esac$/' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg.sh" \
+        | grep -c 'ppa_codename="noble"')
+    en_pre=$(awk '/case "\$ppa_codename" in/,/^            esac$/' \
+        "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh" \
+        | grep -c 'ppa_codename="noble"')
+    [ "$ru_pre" -eq "$en_pre" ]
+    [ "$ru_pre" -ge 1 ]
+}
+
+# ---------- functional: ppa_codename resolution under mocked curl ----------
+
+# Helper: extract a copy of the pre-check `case` and evaluate it with
+# whatever curl behaviour the test set up. We replicate the block here
+# instead of sourcing the installer (which would pull in side effects).
+run_pre_check() {
+    local ppa_codename="$1"
+    case "$ppa_codename" in
+        noble|jammy|focal) ;;
+        *)
+            if ! curl -fsI --max-time 15 --retry 2 --retry-delay 5 \
+                "https://ppa.launchpadcontent.net/amnezia/ppa/ubuntu/dists/${ppa_codename}/Release" \
+                >/dev/null 2>&1; then
+                ppa_codename="noble"
+            fi
+            ;;
+    esac
+    echo "$ppa_codename"
+}
+
+@test "v5.13.0: questing + curl 404 -> noble" {
+    curl() { return 22; }   # curl's "HTTP error" exit code
+    export -f curl
+    result=$(run_pre_check questing)
+    [ "$result" = "noble" ]
+}
+
+@test "v5.13.0: questing + curl timeout/network fail -> noble" {
+    curl() { return 28; }   # curl's "operation timeout" exit code
+    export -f curl
+    result=$(run_pre_check questing)
+    [ "$result" = "noble" ]
+}
+
+@test "v5.13.0: questing + curl success -> questing (no fallback)" {
+    curl() { return 0; }
+    export -f curl
+    result=$(run_pre_check questing)
+    [ "$result" = "questing" ]
+}
+
+@test "v5.13.0: noble skips pre-check entirely (curl never called)" {
+    curl() { echo "CURL SHOULD NOT BE CALLED" >&2; return 1; }
+    export -f curl
+    result=$(run_pre_check noble)
+    [ "$result" = "noble" ]
+}
+
+@test "v5.13.0: jammy skips pre-check entirely" {
+    curl() { return 1; }
+    export -f curl
+    result=$(run_pre_check jammy)
+    [ "$result" = "jammy" ]
+}
+
+@test "v5.13.0: focal skips pre-check entirely" {
+    curl() { return 1; }
+    export -f curl
+    result=$(run_pre_check focal)
+    [ "$result" = "focal" ]
+}
+
+@test "v5.13.0: plucky (future non-LTS) + curl 404 -> noble" {
+    curl() { return 22; }
+    export -f curl
+    result=$(run_pre_check plucky)
+    [ "$result" = "noble" ]
+}
+
+# ---------- functional: suite-mismatch detection ----------
+
+@test "v5.13.0: existing Suites=questing + target=noble -> file gets deleted" {
+    tmpdir=$(mktemp -d)
+    ppa_sources="$tmpdir/amnezia-ppa.sources"
+    ppa_list="$tmpdir/amnezia-ppa.list"
+    cat > "$ppa_sources" <<EOF
+Types: deb
+URIs: https://ppa.launchpadcontent.net/amnezia/ppa/ubuntu
+Suites: questing
+Components: main
+Signed-By: /etc/apt/keyrings/amnezia-ppa.gpg
+EOF
+    ppa_codename="noble"
+
+    # Inline the v5.13.0 logic
+    existing_suite=""
+    if [[ -f "$ppa_sources" ]]; then
+        existing_suite=$(awk '/^Suites:/{print $2; exit}' "$ppa_sources" 2>/dev/null)
+    fi
+    [ "$existing_suite" = "questing" ]
+
+    if [[ -n "$existing_suite" && "$existing_suite" != "$ppa_codename" ]]; then
+        rm -f "$ppa_sources" "$ppa_list"
+    fi
+    [ ! -f "$ppa_sources" ]
+    rm -rf "$tmpdir"
+}
+
+@test "v5.13.0: existing Suites=noble + target=noble -> file preserved" {
+    tmpdir=$(mktemp -d)
+    ppa_sources="$tmpdir/amnezia-ppa.sources"
+    ppa_list="$tmpdir/amnezia-ppa.list"
+    cat > "$ppa_sources" <<EOF
+Types: deb
+URIs: https://ppa.launchpadcontent.net/amnezia/ppa/ubuntu
+Suites: noble
+Components: main
+Signed-By: /etc/apt/keyrings/amnezia-ppa.gpg
+EOF
+    ppa_codename="noble"
+
+    existing_suite=""
+    if [[ -f "$ppa_sources" ]]; then
+        existing_suite=$(awk '/^Suites:/{print $2; exit}' "$ppa_sources" 2>/dev/null)
+    fi
+    [ "$existing_suite" = "noble" ]
+
+    if [[ -n "$existing_suite" && "$existing_suite" != "$ppa_codename" ]]; then
+        rm -f "$ppa_sources" "$ppa_list"
+    fi
+    [ -f "$ppa_sources" ]
+    rm -rf "$tmpdir"
+}
+
+@test "v5.13.0: missing .sources -> suite-mismatch logic is a no-op" {
+    tmpdir=$(mktemp -d)
+    ppa_sources="$tmpdir/does-not-exist.sources"
+    ppa_codename="noble"
+
+    existing_suite=""
+    if [[ -f "$ppa_sources" ]]; then
+        existing_suite=$(awk '/^Suites:/{print $2; exit}' "$ppa_sources" 2>/dev/null)
+    fi
+    [ -z "$existing_suite" ]
+
+    # mismatch condition shouldn't trigger
+    if [[ -f "$ppa_sources" && ( -z "$existing_suite" || "$existing_suite" != "$ppa_codename" ) ]]; then
+        rm -f "$ppa_sources"
+    fi
+    [ ! -f "$ppa_sources" ]   # never existed
+    rm -rf "$tmpdir"
+}
+
+# ---------- functional: corrupt .sources (no Suites: line) ----------
+
+@test "v5.13.0: corrupt .sources (no Suites line) gets recreated" {
+    tmpdir=$(mktemp -d)
+    ppa_sources="$tmpdir/amnezia-ppa.sources"
+    ppa_list="$tmpdir/amnezia-ppa.list"
+    # Garbage file — exists but no Suites: line (manual edit gone wrong,
+    # half-written by a crashed dpkg, etc.)
+    cat > "$ppa_sources" <<EOF
+Types: deb
+URIs: https://ppa.launchpadcontent.net/amnezia/ppa/ubuntu
+# Suites: removed by hand
+Components: main
+Signed-By: /etc/apt/keyrings/amnezia-ppa.gpg
+EOF
+    ppa_codename="noble"
+
+    existing_suite=""
+    if [[ -f "$ppa_sources" ]]; then
+        existing_suite=$(awk '/^Suites:/{print $2; exit}' "$ppa_sources" 2>/dev/null)
+    fi
+    [ -z "$existing_suite" ]
+
+    # New logic: empty suite + file exists => rewrite
+    if [[ -f "$ppa_sources" && ( -z "$existing_suite" || "$existing_suite" != "$ppa_codename" ) ]]; then
+        rm -f "$ppa_sources" "$ppa_list"
+    fi
+    [ ! -f "$ppa_sources" ]
+    rm -rf "$tmpdir"
+}
+
+# ---------- functional: legacy .sources mismatch ----------
+
+@test "v5.13.0: legacy .sources with questing suite + target noble -> removed" {
+    tmpdir=$(mktemp -d)
+    legacy_sources="$tmpdir/amnezia-ubuntu-ppa-questing.sources"
+    legacy_list="$tmpdir/amnezia-ubuntu-ppa-questing.list"
+    cat > "$legacy_sources" <<EOF
+Types: deb
+URIs: https://ppa.launchpadcontent.net/amnezia/ppa/ubuntu
+Suites: questing
+Components: main
+Signed-By: /etc/apt/keyrings/amnezia-ppa.gpg
+EOF
+    ppa_codename="noble"
+
+    legacy_suite=""
+    if [[ -f "$legacy_sources" ]]; then
+        legacy_suite=$(awk '/^Suites:/{print $2; exit}' "$legacy_sources" 2>/dev/null)
+    fi
+    [ "$legacy_suite" = "questing" ]
+
+    if [[ -f "$legacy_sources" && ( -z "$legacy_suite" || "$legacy_suite" != "$ppa_codename" ) ]]; then
+        rm -f "$legacy_sources" "$legacy_list"
+    fi
+    [ ! -f "$legacy_sources" ]
+    rm -rf "$tmpdir"
+}
+
+@test "v5.13.0: legacy .sources with matching suite -> preserved" {
+    tmpdir=$(mktemp -d)
+    legacy_sources="$tmpdir/amnezia-ubuntu-ppa-noble.sources"
+    legacy_list="$tmpdir/amnezia-ubuntu-ppa-noble.list"
+    cat > "$legacy_sources" <<EOF
+Types: deb
+URIs: https://ppa.launchpadcontent.net/amnezia/ppa/ubuntu
+Suites: noble
+Components: main
+Signed-By: /etc/apt/keyrings/amnezia-ppa.gpg
+EOF
+    ppa_codename="noble"
+
+    legacy_suite=""
+    if [[ -f "$legacy_sources" ]]; then
+        legacy_suite=$(awk '/^Suites:/{print $2; exit}' "$legacy_sources" 2>/dev/null)
+    fi
+    [ "$legacy_suite" = "noble" ]
+
+    if [[ -f "$legacy_sources" && ( -z "$legacy_suite" || "$legacy_suite" != "$ppa_codename" ) ]]; then
+        rm -f "$legacy_sources" "$legacy_list"
+    fi
+    [ -f "$legacy_sources" ]
+    rm -rf "$tmpdir"
+}


### PR DESCRIPTION
**v5.13.0** — Ubuntu 25.10 / 26.04 support via PPA noble fallback + `--force` safety guard.

## Scope (single PR, 5 fixes)

1. **PPA noble fallback** (Issue #46): pre-check `dists/<codename>/Release` for Ubuntu non-LTS, remap suite to `noble` on 404. Plus: gcc-13 pre-install when stale non-running kernel headers detected; DKMS-for-running-kernel fallback if apt install fails; suite-mismatch detection rewrites broken `.sources` from previous failed installs.
2. **`--force` safety guard** (Issue #78): re-run on a server with `awg-quick@awg0` active aborts with a clear message unless `--force` / `AWG_FORCE_REINSTALL=1` is set.
3. **`manage` log_msg WARN → stderr** (rcgr): symmetry with installer; CI/automation can now parse stdout = data, stderr = diagnostics.
4. **`/etc/fstab` swap precise check** (i31a): anchored awk field-match replaces substring grep, comment-resistant + idempotent.
5. **Docs**: README link vpnstatus.online → vpnstatus.site.

## Tests

+68 new bats (test_v5130_ppa_noble_fallback +33, test_v5130_force_guard +19, test_v5130_bundled_fixes +16). Suite total 455 (executed 453, 2 historical non-ASCII skips, 0 fail). `bash -n` + `shellcheck -S warning` clean on all 6 shell files.

## VPS verification

Tested on frankt (Ubuntu 25.10 questing, kernel 6.17.0-23-generic, in-place upgraded from 24.04):
- PPA pre-check correctly detected 404 on `questing` → switched to noble.
- gcc-13 pre-install triggered (stale 6.8.x headers from 24.04 era).
- amneziawg-{dkms,tools} installed cleanly; DKMS module built for 6.17.
- Step 2 finished, reboot, module loaded via systemd unit, Step 3+ proceeded.

## Codex audits

3 rounds (WATCH → GO → GO). All findings addressed: corrupt-`.sources` rewrite, legacy `.sources` suite-mismatch check, RU comment language cleanup, typo fix.

## Release plan

After merge: tag `v5.13.0` → `release.yml` creates Release from CHANGELOG.en.md → manual bilingual notes via `gh release edit --notes-file`. `arm-build.yml` re-publishes 14 ARM prebuilts. Close #46 + #78 with release link.
