### PR TITLE
test: fix bare-! negation in bats (SC2314) - unredden ShellCheck CI

### DIFF
--- a/tests/test_v5141_mtu_resolution.bats
+++ b/tests/test_v5141_mtu_resolution.bats
@@ -12,6 +12,9 @@
 
 load test_helper
 
+# Required for `run !` flag (used in negation tests). Suppresses bats BW02 warning.
+bats_require_minimum_version 1.5.0
+
 setup() {
     TEST_DIR=$(mktemp -d)
     export AWG_DIR="$TEST_DIR"
@@ -159,8 +162,10 @@ CONF
     local FILE="${BATS_TEST_DIRNAME}/../awg_common.sh"
     local block
     block=$(awk '/^render_client_config\(\) \{/,/^}$/' "$FILE")
-    # Must NOT contain literal "MTU = 1280" hardcode
-    ! grep -qE '^MTU = 1280$' <<<"$block"
+    # Must NOT contain literal "MTU = 1280" hardcode.
+    # In Bats a bare `! grep` does NOT fail the test (SC2314); use `run !`
+    # (bats >= 1.5.0) so the negated exit status actually fails the test.
+    run ! grep -qE '^MTU = 1280$' <<<"$block"
     # Must contain template substitution for MTU
     grep -qE 'MTU = \$\{mtu\}' <<<"$block"
 }
@@ -169,7 +174,7 @@ CONF
     local FILE="${BATS_TEST_DIRNAME}/../awg_common_en.sh"
     local block
     block=$(awk '/^render_client_config\(\) \{/,/^}$/' "$FILE")
-    ! grep -qE '^MTU = 1280$' <<<"$block"
+    run ! grep -qE '^MTU = 1280$' <<<"$block"
     grep -qE 'MTU = \$\{mtu\}' <<<"$block"
 }
 

--- a/tests/test_v5142_build_arm_deb.bats
+++ b/tests/test_v5142_build_arm_deb.bats
@@ -11,6 +11,9 @@
 # Otherwise: 0 candidates → fail (unchanged); 1 candidate → use it (unchanged);
 # 2+ candidates → fail with explicit list, ask caller to set KERNEL_VERSION.
 
+# Required for `run !` flag (used in negation tests). Suppresses bats BW02 warning.
+bats_require_minimum_version 1.5.0
+
 setup() {
     TEST_DIR=$(mktemp -d)
     MODULES_ROOT="$TEST_DIR/lib/modules"
@@ -102,6 +105,9 @@ teardown() {
 
 @test "_resolve_kernel_version: empty KERNEL_VERSION falls back to auto-detect" {
     mkdir -p "$MODULES_ROOT/6.12.5-rpi/build"
+    # The helper reads KERNEL_VERSION via ${KERNEL_VERSION:-}, shellcheck cannot
+    # see that cross-function flow and flags this as unused (SC2034).
+    # shellcheck disable=SC2034
     KERNEL_VERSION=""
 
     run _resolve_kernel_version "$MODULES_ROOT"
@@ -127,7 +133,9 @@ teardown() {
 @test "structural: main body uses _resolve_kernel_version (no inline detection loop)" {
     local FILE="$BATS_TEST_DIRNAME/../scripts/build-arm-deb.sh"
     # Inline pre-fix pattern: bare `for _d in /lib/modules/*/build; do`.
-    ! grep -qE '^for _d in /lib/modules/\*/build' "$FILE"
+    # In Bats a bare `! grep` does NOT fail the test (SC2314); use `run !`
+    # (bats >= 1.5.0) so the negated exit status actually fails the test.
+    run ! grep -qE '^for _d in /lib/modules/\*/build' "$FILE"
     # New invocation: KERNEL_VERSION="$(_resolve_kernel_version /lib/modules)" somewhere.
     grep -qE 'KERNEL_VERSION="\$\(_resolve_kernel_version /lib/modules\)"' "$FILE"
 }


### PR DESCRIPTION
## Summary

ShellCheck CI has been red since v5.14.1 (commit `fa14156`) because of SC2314 in two bats files. In Bats a bare `!` does not cause a test failure - three negation checks were silently always green.

## Root cause

- `tests/test_v5141_mtu_resolution.bats:163, 172` - assert that `MTU = 1280` is NOT hardcoded in `render_client_config` block (RU + EN)
- `tests/test_v5142_build_arm_deb.bats:130` - assert no inline `for _d in /lib/modules/*/build` detection loop

All three used `! grep ...` which under Bats does not fail the test. Real validation was disabled without anyone noticing.

## Fix

- Replace bare `!` with `run !` (Bats >= 1.5.0 syntax that asserts a non-zero exit code).
- Add `bats_require_minimum_version 1.5.0` near the top of both files to suppress BW02 warning that fires when using flags on `run` without an explicit version declaration.
- One `# shellcheck disable=SC2034` inline comment for an unrelated false positive in `test_v5142_build_arm_deb.bats:105` (helper reads `KERNEL_VERSION` cross-function, shellcheck cannot follow).

## Why no version bump

Test-only fix. Production scripts not touched. SCRIPT_VERSION unchanged. SHA256 pins unchanged. Per project policy in `CLAUDE.md` (`Bump SCRIPT_VERSION ... only in files that actually changed`), this is a `test:` commit.

## Test plan

- [x] `shellcheck -S warning` across 7 production scripts + 3 modified bats files - 0 warnings
- [x] `bats tests/` full suite - 516 ok / 0 not_ok / 0 BW02 warnings (same 2 pre-existing main-warnings about unicode/quote chars in test names)
- [x] The 3 fixed assertions now correctly FAIL if someone reintroduces `MTU = 1280` hardcode or the inline detection loop (verified via temporary regression in working tree)
- [ ] Green ShellCheck CI on the new commit