### PR TITLE
docs: add "Pick your case" routing block to the above-fold

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -53,6 +53,15 @@ sudo bash ./install_amneziawg_en.sh --yes --route-all
 All parameters are accepted automatically. Details: [ADVANCED.en.md#cli-params-adv](ADVANCED.en.md#cli-params-adv)
 </details>
 
+### 🎯 Pick your case
+
+| Your situation | What to add |
+|---|---|
+| Plain cheap VPS, you just need a VPN | Nothing - the command above already does it |
+| Mobile data, DPI cuts the link (TSPU, Iran, school or office) | During install, add `--preset=mobile` ([tested carriers](#carriers)) |
+| ARM: Raspberry Pi, Oracle Ampere, Hetzner CAX | Same command - ready-made ARM kernel modules are selected automatically ([details](INSTALL_VPS.md)) |
+| Time-limited access for a friend or guest | After install: `manage_amneziawg.sh add guest --expires=7d` |
+
 ---
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ sudo bash ./install_amneziawg.sh --yes --route-all
 Все параметры принимаются автоматически. Подробнее: [ADVANCED.md#cli-params-adv](ADVANCED.md#cli-params-adv)
 </details>
 
+### 🎯 Выберите свой случай
+
+| Ваша ситуация | Что добавить |
+|---|---|
+| Обычный дешёвый VPS, просто нужен VPN | Ничего - команда выше уже всё делает |
+| Мобильный интернет, DPI режет (ТСПУ, Иран, школа или корпоратив) | При установке добавьте `--preset=mobile` ([проверенные операторы](#operatory)) |
+| ARM: Raspberry Pi, Oracle Ampere, Hetzner CAX | Та же команда - готовые ARM-модули ядра выберутся автоматически ([детали](INSTALL_VPS.md)) |
+| Доступ другу или гостю на время | После установки: `manage_amneziawg.sh add guest --expires=7d` |
+
 ---
 
 <p align="center">


### PR DESCRIPTION
## Summary

Adds a compact "Pick your case" routing block to the above-fold, right after Quick Start. It routes visitors by their situation to the right path in a few seconds, without bloating the first screen or duplicating the existing tables.

4 rows:
- Plain cheap VPS - nothing extra, the Quick Start command already does it.
- Mobile data / DPI cuts the link - add `--preset=mobile` at install time, with a link to the tested-carriers table.
- ARM (Raspberry Pi, Oracle Ampere, Hetzner CAX) - same command, ARM kernel modules are selected automatically.
- Time-limited access for a guest - `manage add --expires=7d` after install.

RU and EN READMEs updated symmetrically. Docs-only, no behaviour change. Zero em/en-dashes.

<a id="russian-version"></a>

## Кратко (RU)

Добавляет компактный блок-роутер "Выберите свой случай" в первый экран, сразу после Quick Start. За несколько секунд направляет посетителя по его сценарию к нужному пути, не раздувая первый экран и не дублируя существующие таблицы.

4 строки:
- Обычный дешёвый VPS - ничего лишнего, команда Quick Start уже всё делает.
- Мобильный интернет / DPI режет - при установке добавить `--preset=mobile`, ссылка на таблицу проверенных операторов.
- ARM (Raspberry Pi, Oracle Ampere, Hetzner CAX) - та же команда, ARM-модули ядра выбираются автоматически.
- Доступ гостю на время - `manage add --expires=7d` после установки.

RU и EN README обновлены симметрично. Только документация, поведение не меняется.
