### PR TITLE
ci(docs-check): guard against installer wget snippets missing -O

### DIFF
--- a/scripts/check-docs-consistency.sh
+++ b/scripts/check-docs-consistency.sh
@@ -30,6 +30,9 @@
 #   8. Issue-template: placeholder версии нейтральный (не протухающий X.Y.Z).
 #   9. Матрица OS×arch×prebuilt-target: supported Ubuntu-версии без ARM
 #      prebuilt-таргета в arm-build.yml помечены DKMS-only для ARM в INSTALL_VPS.
+#  10. Установочные/update wget-сниппеты качают install_amneziawg*.sh через -O
+#      (голый wget <url> пишет .1 при повторном запуске, и chmod/bash берут
+#      старый файл; злейший кейс - update-флоу с --force).
 
 set -o pipefail
 
@@ -305,6 +308,31 @@ else
     echo "  нет $arm_yml (проверка ARM prebuilt-матрицы)" >&2; arm_matrix_fail=1
 fi
 if [[ "$arm_matrix_fail" -eq 0 ]]; then _ok "ARM prebuilt-покрытие согласовано (OS×arch×target)"; else _bad "ARM prebuilt-покрытие рассинхронизировано"; fi
+
+# --- 10. Установочные wget-сниппеты используют -O (re-run .1-ловушка) ---
+# Голый `wget <url>/install_amneziawg*.sh` без -O при повторном запуске пишет
+# install_amneziawg.sh.1, а следующий `chmod +x` / `bash install_amneziawg.sh`
+# берут СТАРЫЙ первый файл. Злейший кейс - update-флоу с `--force`: старый скрипт
+# присутствует всегда, и юзер переустанавливает прошлую версию, думая что
+# обновился. Все сниппеты обязаны пинить имя через `-O` (паттерн как в FAQ
+# recovery). Регрессия, ради которой добавлена проверка (PR #114). Детект (два
+# шага): строка вызывает `wget` и качает install_amneziawg*.sh по raw-URL, но в
+# ней нет `-O`/`--output-document` (пин имени). Ловит и `wget -q <url>` с флагами
+# перед URL, не только голую форму. `wget -O name url`, `wget -O- url | bash` и
+# `curl`-альтернативы (без `wget`) под паттерн не попадают.
+wget_o_fail=0
+WGET_DOCS=(README.md README.en.md ADVANCED.md ADVANCED.en.md INSTALL_VPS.md)
+for f in "${WGET_DOCS[@]}"; do
+    [[ -f "$f" ]] || continue
+    while IFS= read -r hit; do
+        [[ -z "$hit" ]] && continue
+        echo "  $f:$hit" >&2
+        echo "    ^ wget без -O: повторный запуск возьмёт .1; используйте 'wget -O <файл> <url>'" >&2
+        wget_o_fail=1
+    done < <(grep -nE 'wget[[:space:]].*https?://[^[:space:]]*install_amneziawg[a-z_]*\.sh' "$f" \
+             | grep -vE -- '(^|[[:space:]])(-O|--output-document)')
+done
+if [[ "$wget_o_fail" -eq 0 ]]; then _ok "установочные wget-сниппеты используют -O (нет .1-ловушки)"; else _bad "wget-сниппет без -O (.1-ловушка вернулась)"; fi
 
 # --- Summary ---
 echo ""

--- a/tests/test_v5153_docs_check.bats
+++ b/tests/test_v5153_docs_check.bats
@@ -17,8 +17,9 @@ TMPL_STALE_RE='placeholder:[[:space:]]*"e\.g\.,[[:space:]]*[0-9]+\.[0-9]+\.[0-9]
 @test "T6: check-docs-consistency passes on the current repo" {
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
-    # 10 checks since 1bkk added the OS x arch x prebuilt-target matrix check (#9).
-    [[ "$output" == *"10 passed, 0 failed"* ]]
+    # 11 checks since the installer wget -O guard (#10) joined the OS x arch x
+    # prebuilt-target matrix check (#9).
+    [[ "$output" == *"11 passed, 0 failed"* ]]
 }
 
 @test "T6: script defines checks #7 and #8" {

--- a/tests/test_v5153_docs_check_slug.bats
+++ b/tests/test_v5153_docs_check_slug.bats
@@ -52,8 +52,8 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
-@test ".4 integration: docs-check still passes 10/10 with ROADMAP included" {
+@test ".4 integration: docs-check still passes 11/11 with ROADMAP included" {
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"10 passed, 0 failed"* ]]
+    [[ "$output" == *"11 passed, 0 failed"* ]]
 }


### PR DESCRIPTION
## What

Add check #10 to `scripts/check-docs-consistency.sh`: any `wget` that downloads `install_amneziawg*.sh` from a raw URL must pin the output name with `-O` (or `--output-document`).

## Why

Bare `wget <url>` writes `install_amneziawg.sh.1` on a second run, so the follow-up `chmod +x install_amneziawg.sh && bash install_amneziawg.sh` silently runs the stale first copy. The worst case is the update flow with `--force`. PR #114 fixed the docs; this guard prevents the regression from coming back.

## Detection

Two-step: a line that calls `wget` on the installer raw URL and lacks `-O`/`--output-document`. This also catches `wget -q <url>` (flags before the URL), while `wget -O- url | bash` and `curl` alternatives are not flagged.

## Verification

- Synthetic classification over 8 line variants: flags only the three real traps (bare, blockquoted `>`, `wget -q`); leaves `-O`, `-O- | bash`, `--output-document`, `curl`, and prose alone.
- Positive run: 11/11 pass.
- Negative test: reintroducing a bare `wget` (and a `wget -q` variant) fails the check with the correct file:line.
- `shellcheck -S warning`: clean.

No CHANGELOG entry (internal CI tooling). The `docs-check.yml` path filter already includes this script, so the new check runs on this PR.
