### PR TITLE
docs: server-transparency block + SHA256 integrity note (RU and EN)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -41,7 +41,22 @@ sudo bash ./install_amneziawg_en.sh
 
 > 📘 Full deployment guide: [Install AmneziaWG VPN server on Ubuntu/Debian VPS](INSTALL_VPS.md) - covers VPS choice, ARM, troubleshooting, and uninstall.
 
-> 🔐 Integrity: the script is fetched over HTTPS from `raw.githubusercontent.com` (pinned tag). Detached release signatures are not active yet (planned) - status and threat model in [SECURITY.md](SECURITY.md).
+> 🔐 Integrity: the script is fetched over HTTPS from `raw.githubusercontent.com` (pinned tag), and the helper scripts (`awg_common`, `manage`) are verified against pinned SHA256 hashes. Detached release signatures are not active yet (planned) - status and threat model in [SECURITY.md](SECURITY.md).
+
+<details>
+<summary><strong>What the installer changes on your server (transparency)</strong></summary>
+
+The script runs as root - here is a short list of what it does to the system:
+
+- **Packages**: updates the system, installs dependencies (amneziawg-tools, qrencode, etc.); on Ubuntu removes leftovers from the minimal install (snapd, modemmanager).
+- **Kernel**: adds the Amnezia PPA (GPG key verified by full fingerprint) and builds the AmneziaWG module via DKMS.
+- **Network**: sysctl - forwarding, network buffers, BBR (as separate files in `/etc/sysctl.d/`); host IPv6 is disabled by default (keep it with `--allow-ipv6`); swap is sized to fit the RAM.
+- **Protection**: UFW - incoming denied, SSH rate-limited, only the VPN UDP port open; Fail2Ban for SSH.
+- **Files and services**: the main files live in `/root/awg/` and `/etc/amnezia/amneziawg/` with 600/700 permissions; the `awg-quick@awg0` service; a cron job that removes expired clients.
+- **Rollback**: `--uninstall` removes everything of its own (module, configs, sysctl files, firewall rules, cron jobs). It disables UFW and purges the Fail2Ban package only if it installed them itself. It does not restore: swap settings and removed packages.
+
+Step-by-step details in [ADVANCED.en.md](ADVANCED.en.md), threat model in [SECURITY.md](SECURITY.md).
+</details>
 
 <details>
 <summary><strong>Non-interactive installation (for automation)</strong></summary>

--- a/README.md
+++ b/README.md
@@ -42,7 +42,22 @@ sudo bash ./install_amneziawg.sh
 
 > 📘 Полный гайд по развёртыванию (EN): [Install AmneziaWG VPN server on Ubuntu/Debian VPS](INSTALL_VPS.md) - выбор VPS, ARM, troubleshooting, удаление.
 
-> 🔐 Целостность: скрипт качается по HTTPS с `raw.githubusercontent.com` (тег закреплён). Отдельные detached-подписи релизов пока не активны (запланированы) - статус и модель угроз в [SECURITY.md](SECURITY.md).
+> 🔐 Целостность: скрипт качается по HTTPS с `raw.githubusercontent.com` (тег закреплён), вспомогательные скрипты (`awg_common`, `manage`) проверяются по закреплённым SHA256-хешам. Отдельные detached-подписи релизов пока не активны (запланированы) - статус и модель угроз в [SECURITY.md](SECURITY.md).
+
+<details>
+<summary><strong>Что установщик меняет на сервере (прозрачность)</strong></summary>
+
+Скрипт получает root - вот краткий список того, что он делает с системой:
+
+- **Пакеты**: обновляет систему, ставит зависимости (amneziawg-tools, qrencode и т.д.); на Ubuntu убирает лишнее из минимальной установки (snapd, modemmanager).
+- **Ядро**: подключает PPA Amnezia (GPG-ключ проверяется по полному отпечатку) и собирает модуль AmneziaWG через DKMS.
+- **Сеть**: sysctl - форвардинг, сетевые буферы, BBR (отдельными файлами в `/etc/sysctl.d/`); IPv6 на хосте по умолчанию выключается (оставить: `--allow-ipv6`); swap подгоняется под размер RAM.
+- **Защита**: UFW - входящие запрещены, SSH с rate-limit, открыт только UDP-порт VPN; Fail2Ban для SSH.
+- **Файлы и сервисы**: основные файлы в `/root/awg/` и `/etc/amnezia/amneziawg/` с правами 600/700; сервис `awg-quick@awg0`; крон автоудаления истёкших клиентов.
+- **Откат**: `--uninstall` убирает всё своё (модуль, конфиги, sysctl-файлы, правила firewall, кроны). UFW отключает и пакет Fail2Ban удаляет только если сам их ставил. Не возвращает: swap и удалённые пакеты.
+
+Пошаговые детали - в [ADVANCED.md](ADVANCED.md), модель угроз - в [SECURITY.md](SECURITY.md).
+</details>
 
 <details>
 <summary><strong>Неинтерактивная установка (для автоматизации)</strong></summary>


### PR DESCRIPTION
## Что и зачем

Trust-блок для README (закрывает promo-задачу по прозрачности): пользователь даёт установщику root, поэтому добавлен честный обзор того, что скрипт меняет на сервере.

### Изменения
1. **Integrity-нота** дополнена фактом: вспомогательные скрипты (`awg_common`, `manage`) проверяются по закреплённым SHA256-хешам (это уже работает в v5.16.0). Detached-подписи релизов остаются "запланированы" (не заявляются активными).
2. **Свёрнутый блок "Что установщик меняет на сервере"** (RU + EN, симметрично) сразу после integrity-ноты в Quick start: пакеты, ядро/PPA/DKMS, sysctl/IPv6/swap, UFW/Fail2Ban, файлы и права, поведение `--uninstall` (честно: swap и снятые пакеты не возвращаются).

### Проверки
- Все факты сверены с `install_amneziawg.sh` v5.16.0 (маркер-условия UFW/Fail2Ban, состав uninstall, полный GPG-fingerprint, SHA256-пины).
- `check-docs-consistency.sh`: 8/8 PASS.
- Только hyphen-minus (em/en-dash = 0). RU/EN паритет.
- Docs-only: чек "Lint and syntax check" не запускается (path-filter), мерж admin.