### PR TITLE
docs: link the comparison page from README, fix ADVANCED wording

### DIFF
--- a/ADVANCED.en.md
+++ b/ADVANCED.en.md
@@ -676,7 +676,7 @@ chmod 700 /root/awg/manage_amneziawg.sh /root/awg/awg_common.sh
     <li>Fine tuning is available: a mobile-network preset and direct access to the AWG 2.0 parameters.</li>
     <li>Management is from the CLI (<code>manage</code> add/remove/list/<code>--expires</code>), with prebuilt ARM modules and a headless mode for automation.</li>
   </ul>
-  A breakdown with examples is on the <a href="https://bivlked.github.io/amneziawg-installer/compare/">comparison page</a>.
+  A detailed comparison is on the <a href="https://bivlked.github.io/amneziawg-installer/compare/">comparison page</a>.
 </details>
 
 <details>

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -672,7 +672,7 @@ chmod 700 /root/awg/manage_amneziawg.sh /root/awg/awg_common.sh
     <li>Доступна тонкая настройка: пресет для мобильных сетей и прямой доступ к параметрам AWG 2.0.</li>
     <li>Управление из CLI (<code>manage</code> add/remove/list/<code>--expires</code>), готовые сборки под ARM, headless-режим для автоматизации.</li>
   </ul>
-  Разбор с примерами - на <a href="https://bivlked.github.io/amneziawg-installer/ru/compare/">странице сравнения</a>.
+  Подробное сравнение - на <a href="https://bivlked.github.io/amneziawg-installer/ru/compare/">отдельной странице</a>.
 </details>
 
 <details>

--- a/README.en.md
+++ b/README.en.md
@@ -186,6 +186,8 @@ The official Amnezia app is the official graphical client: you install the app, 
 
 The protocol and the DPI resistance are the same - it is the same AmneziaWG 2.0 underneath. The code is open under the MIT license, it is readable bash you can review before running, and it has 800+ automated tests. It installs the same upstream AmneziaWG - this is automation and server tuning, not a fork of the protocol.
 
+Detailed comparison: [amneziawg-installer vs the official Amnezia app](https://bivlked.github.io/amneziawg-installer/compare/).
+
 ---
 
 <a id="features"></a>

--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ sudo bash ./install_amneziawg.sh --yes --route-all
 
 Протокол и стойкость к DPI при этом одинаковые - под капотом тот же AmneziaWG 2.0. Код открыт под MIT, это читаемый bash, его можно просмотреть перед запуском, на нём 800+ автотестов. Ставится тот же upstream AmneziaWG - это автоматизация и тюнинг сервера, а не форк протокола.
 
+Подробное сравнение: [amneziawg-installer и официальное приложение Amnezia](https://bivlked.github.io/amneziawg-installer/ru/compare/).
+
 ---
 
 <a id="vozmozhnosti"></a>


### PR DESCRIPTION
## What

Follow-up to #121. Two small doc fixes:

- **README.md / README.en.md**: a short cross-link at the end of the "how it differs" section pointing to the standalone comparison page (`/compare/`, `/ru/compare/`). The README had no link to it before. Keyword-matched anchor for the comparison search intent.
- **ADVANCED.md / ADVANCED.en.md**: corrected the FAQ wording. The page is a structured comparison, not a walkthrough with examples, so "with examples / с примерами" was inaccurate.

## Notes

- Docs only. No script or CHANGELOG changes.
- `scripts/check-docs-consistency.sh`: 11/11 pass locally.
- Hyphen-minus only in new text.
