### PR TITLE
docs: add a project website badge to the README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -12,6 +12,7 @@
 <p align="center"><em>One-command, self-hosted AmneziaWG 2.0 VPN for Ubuntu 24.04 / 25.10 and Debian 12 / 13. Kernel-native DKMS, no Docker, no web panel, runs on any cheap VPS.</em></p>
 
 <p align="center">
+  <a href="https://bivlked.github.io/amneziawg-installer/"><img src="https://img.shields.io/badge/Website-bivlked.github.io-3ddc97" alt="Project website"></a>
   <img src="https://img.shields.io/badge/Ubuntu-24.04_|_25.10_|_26.04-orange" alt="Ubuntu 24.04 | 25.10 | 26.04">
   <img src="https://img.shields.io/badge/Debian-12_|_13-A81D33" alt="Debian 12 | 13">
   <img src="https://img.shields.io/badge/Architecture-x86__64_|_ARM64_|_ARMv7-green" alt="x86_64 | ARM64 | ARMv7">

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 <p align="center"><em>One-command, self-hosted AmneziaWG 2.0 VPN for Ubuntu 24.04 / 25.10 and Debian 12 / 13. Kernel-native DKMS, no Docker, no web panel, runs on any cheap VPS.</em></p>
 
 <p align="center">
+  <a href="https://bivlked.github.io/amneziawg-installer/ru/"><img src="https://img.shields.io/badge/Website-bivlked.github.io-3ddc97" alt="Project website"></a>
   <img src="https://img.shields.io/badge/Ubuntu-24.04_|_25.10_|_26.04-orange" alt="Ubuntu 24.04 | 25.10 | 26.04">
   <img src="https://img.shields.io/badge/Debian-12_|_13-A81D33" alt="Debian 12 | 13">
   <img src="https://img.shields.io/badge/Architecture-x86__64_|_ARM64_|_ARMv7-green" alt="x86_64 | ARM64 | ARMv7">


### PR DESCRIPTION
## What

Adds a project website badge to the README header badge row, linking to the GitHub Pages site. The README had no link to the site before.

- README.md (RU) links to the RU homepage `/amneziawg-installer/ru/`.
- README.en.md (EN) links to the EN homepage `/amneziawg-installer/`.

Placed first in the badge row, brand-colored, so it does not clash with the green license/arch badges.

## Notes

- Docs only. No script or CHANGELOG changes.
- `scripts/check-docs-consistency.sh`: 11/11 pass locally.
