### PR TITLE
docs(changelog): point the Unreleased link at v5.26.0

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -1713,7 +1713,7 @@ Major security and reliability update after several consecutive code audits. The
 - Diagnostic report (`--diagnostic`).
 - Full uninstall (`--uninstall`).
 
-[Unreleased]: https://github.com/bivlked/amneziawg-installer/compare/v5.24.0...HEAD
+[Unreleased]: https://github.com/bivlked/amneziawg-installer/compare/v5.26.0...HEAD
 [5.26.0]: https://github.com/bivlked/amneziawg-installer/compare/v5.25.0...v5.26.0
 [5.25.0]: https://github.com/bivlked/amneziawg-installer/compare/v5.24.0...v5.25.0
 [5.24.0]: https://github.com/bivlked/amneziawg-installer/compare/v5.23.0...v5.24.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1713,7 +1713,7 @@ Hardening-фиксы надёжности и безопасности по ре�
 - Диагностический отчет (`--diagnostic`).
 - Полная деинсталляция (`--uninstall`).
 
-[Unreleased]: https://github.com/bivlked/amneziawg-installer/compare/v5.24.0...HEAD
+[Unreleased]: https://github.com/bivlked/amneziawg-installer/compare/v5.26.0...HEAD
 [5.26.0]: https://github.com/bivlked/amneziawg-installer/compare/v5.25.0...v5.26.0
 [5.25.0]: https://github.com/bivlked/amneziawg-installer/compare/v5.24.0...v5.25.0
 [5.24.0]: https://github.com/bivlked/amneziawg-installer/compare/v5.23.0...v5.24.0


### PR DESCRIPTION
Ссылка `[Unreleased]` в обоих CHANGELOG осталась на `v5.24.0` ещё с релиза 5.25.0, поэтому сравнение "Unreleased" показывало два уже выпущенных релиза как невыпущенные.

Нашло ревью перед тегом v5.26.0. `check-docs-consistency.sh` эту ссылку не проверяет, поэтому она молча проехала через два релиза.

Правка только в двух строках, поведения не касается.