### PR TITLE
fix: compare SHA pins against the tag the installer downloads from

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,9 @@ name: Tests
 on:
   push:
     branches: [main]
-    paths: ['*.sh', 'scripts/**', 'tests/**']
+    paths: ['*.sh', 'scripts/**', 'tests/**', '.github/workflows/test.yml']
   pull_request:
-    paths: ['*.sh', 'scripts/**', 'tests/**']
+    paths: ['*.sh', 'scripts/**', 'tests/**', '.github/workflows/test.yml']
 
 permissions:
   contents: read
@@ -20,6 +20,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The SHA pin lockstep test compares each pin with the helper's
+          # bytes at the tag the installer downloads from, so the tags and
+          # their objects have to be here. On the branch and pull_request
+          # events above the default checkout fetches neither (fetch-depth: 1,
+          # fetch-tags: false), and the test then fails loudly rather than
+          # degrade to a comparison that would mean nothing.
+          fetch-depth: 0
 
       - name: Install bats
         run: sudo apt-get update && sudo apt-get install -y bats

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,12 @@ Before submitting a PR, ensure:
    ```bash
    bats tests/
    ```
+   > Clone with tags. `tests/test_v515_sha_pins_lockstep.bats` compares the
+   > installers' SHA pins with the helper bytes at the release tag, so a
+   > shallow clone (`git clone --depth 1`, which carries no tags) fails those
+   > four tests for an environment reason rather than a real one. A plain
+   > `git clone` is enough; `git fetch --tags` repairs an existing shallow one.
+
    If you add a new function, add a corresponding test file (see `tests/test_*.bats` for the existing pattern). `test_helper.bash` provides common fixtures. Tests must pass on Linux with `flock` available; cross-platform edge cases use the `require_flock` skip helper where needed.
 
 4. **VPS testing** (for script changes): test on a clean server (Ubuntu 24.04 LTS or Debian 12/13 minimal). The full test matrix includes:

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -39,6 +39,21 @@ On every release, regardless of which files changed content:
    A mismatched pin means a fresh install fails the over-the-network integrity
    check, so the pins must be recomputed after the helper scripts are final and
    before the tag is pushed.
+
+   The pin's source of truth is the helper's bytes at the tag the installer
+   downloads from (`AWG_BRANCH` defaults to `v$SCRIPT_VERSION`), not the bytes
+   in your working tree. Both `update-sha-pins.sh` and the lockstep test follow
+   that rule: while `vX.Y.Z` does not exist they compare against the tree, which
+   is why the pins are recomputed after the version bump and before the tag.
+   After the tag exists they compare against the tag, so a helper edited on main
+   without a version bump does not turn the gate red - the published installer
+   is still correct.
+
+   Run `git fetch --tags --force` before the preflight. Both tools read the
+   local tag set, so a checkout that never fetched `vX.Y.Z`, or one whose tag
+   moved under `git tag -f`, will silently compare against the working tree
+   instead. They announce which of the two comparisons they made; read that
+   line rather than only the exit code.
 3. Bump the pinned raw-URL tags in `README*.md`, `ADVANCED*.md` and
    `INSTALL_VPS*.md` from the previous `vX.Y.Z` to the new one. Users copy the
    install and update one-liners verbatim, so a stale tag silently installs the

--- a/scripts/update-sha-pins.sh
+++ b/scripts/update-sha-pins.sh
@@ -48,6 +48,77 @@ _sha256() {
     sha256sum "$1" | cut -d' ' -f1
 }
 
+# Откуда установщик РЕАЛЬНО скачает помощника: он берёт его с
+# raw.githubusercontent.com/<repo>/${AWG_BRANCH}/<helper>, где AWG_BRANCH по
+# умолчанию равен v$SCRIPT_VERSION. Значит эталон для пина - байты помощника
+# НА ТЕГЕ, и только пока тега нет (релиз готовится, тег пушится последним)
+# эталоном служит рабочее дерево.
+#
+# ВАЖНО, ЧЕГО ЭТА ЛОГИКА НЕ УМЕЕТ: локальный набор тегов принимается за истину.
+# Чекаут, в котором тег v$SCRIPT_VERSION просто не выкачан (shallow, --no-tags,
+# форк, сделанный до тега) либо устарел после git tag -f, неотличим здесь от
+# честного "релиз готовится". Поэтому переход на дерево ОБЪЯВЛЯЕТСЯ вслух, а
+# перед выпуском полагается git fetch --tags --force (docs/RELEASE_PROCESS.md).
+_tag_of_installer() {
+    local ver
+    ver="$(grep -oP '^SCRIPT_VERSION="\K[0-9.]+' "$REPO_ROOT/$1" | head -n1)"
+    [[ -n "$ver" ]] || return 1
+    printf 'v%s' "$ver"
+}
+
+# sha содержимого пути НА ТЕГЕ. Через временный файл, а не через $(...):
+# подстановка срезала бы завершающие переводы строк и изменила хеш, а
+# конвейер "git show | sha256sum" на пустом выводе честно посчитал бы хеш
+# ПУСТОГО ВВОДА - 64 валидных hex-символа, которые прошли бы любую проверку
+# длины и выглядели бы как настоящий эталон.
+_sha256_at_tag() {
+    local tag="$1" path="$2" tmp out
+    tmp="$(mktemp)" || return 1
+    if ! git -C "$REPO_ROOT" show "refs/tags/$tag:$path" > "$tmp" 2>/dev/null; then
+        rm -f "$tmp"
+        return 1
+    fi
+    out="$(_sha256 "$tmp")"
+    rm -f "$tmp"
+    [[ "$out" =~ ^[0-9a-f]{64}$ ]] || return 1
+    printf '%s' "$out"
+}
+
+# Печатает "<sha> <источник>", где источник - "tag vX.Y.Z" либо "worktree".
+# При невозможности определить не печатает В STDOUT ничего и возвращает !=0.
+# Вызывающий ОБЯЗАН проверять этот код возврата отдельным присваиванием:
+# "read ... <<< $(...)" его не увидит, потому что here-string всегда даёт
+# перевод строки и read возвращает 0 даже на пустом выводе.
+_expected_sha() {
+    local installer="$1" helper="$2" tag sha
+    if ! git -C "$REPO_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+        echo "ОШИБКА: не git-чекаут, эталон для пина определить нечем" >&2
+        return 1
+    fi
+    if [[ -z "$(git -C "$REPO_ROOT" tag --list | head -n1)" ]]; then
+        echo "ОШИБКА: в чекауте нет ни одного тега (склонируйте с тегами)" >&2
+        return 1
+    fi
+    tag="$(_tag_of_installer "$installer")" || {
+        echo "ОШИБКА: не удалось прочитать SCRIPT_VERSION из $installer" >&2
+        return 1
+    }
+    if git -C "$REPO_ROOT" rev-parse -q --verify "refs/tags/$tag" >/dev/null 2>&1; then
+        if ! sha="$(_sha256_at_tag "$tag" "$helper")"; then
+            # Причину не называем: сюда приводит и отсутствие файла на теге, и
+            # повреждённый объект, и недокачанный shallow-чекаут.
+            echo "ОШИБКА: не удалось прочитать $tag:$helper" >&2
+            return 1
+        fi
+        printf '%s tag %s' "$sha" "$tag"
+        return 0
+    fi
+    echo "ЗАМЕЧАНИЕ: тега $tag в этом чекауте нет - считаю, что релиз готовится," >&2
+    echo "           и сверяю с рабочим деревом. Если тег уже опубликован," >&2
+    echo "           выполните git fetch --tags --force и повторите." >&2
+    printf '%s worktree' "$(_sha256 "$REPO_ROOT/$helper")"
+}
+
 # Прочитать текущий пин из установщика (первое совпадение).
 _read_pin() {
     local installer="$1" pin_name="$2"
@@ -72,6 +143,8 @@ _write_pin() {
 
 rc=0
 mismatched=()
+actual_src=""
+expected_line=""
 
 for entry in "${PIN_MAP[@]}"; do
     IFS='|' read -r installer pin_name helper <<< "$entry"
@@ -87,7 +160,11 @@ for entry in "${PIN_MAP[@]}"; do
         continue
     fi
 
-    actual="$(_sha256 "$REPO_ROOT/$helper")"
+    if ! expected_line="$(_expected_sha "$installer" "$helper")"; then
+        rc=1
+        continue
+    fi
+    read -r actual actual_src <<< "$expected_line"
     pinned="$(_read_pin "$installer" "$pin_name")"
 
     if [[ -z "$actual" || ${#actual} -ne 64 ]]; then
@@ -102,17 +179,21 @@ for entry in "${PIN_MAP[@]}"; do
     fi
 
     if [[ "$actual" == "$pinned" ]]; then
-        echo "OK:    $installer $pin_name = $actual ($helper)"
+        echo "OK:    $installer $pin_name = $actual ($helper, $actual_src)"
         continue
     fi
 
     if [[ "$VERIFY_ONLY" -eq 1 ]]; then
         echo "MISMATCH: $installer $pin_name" >&2
         echo "          pinned: $pinned" >&2
-        echo "          actual: $actual ($helper)" >&2
+        echo "          ожидалось: $actual ($helper, источник: $actual_src)" >&2
         mismatched+=("$installer:$pin_name")
         rc=1
     else
+        # Записывается ЭТАЛОН, а не хеш дерева: при существующем теге это
+        # байты с тега, то есть ровно то, что установщик примет. Прежняя
+        # редакция здесь отказывалась писать и тем блокировала единственную
+        # верную починку разъехавшегося пина.
         if _write_pin "$installer" "$pin_name" "$actual"; then
             echo "UPDATE: $installer $pin_name -> $actual ($helper)"
         else

--- a/tests/test_sha_pin_source_of_truth.bats
+++ b/tests/test_sha_pin_source_of_truth.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+# scripts/update-sha-pins.sh - the pin's source of truth.
+#
+# The script decides what a pin OUGHT to be, and until now nothing tested it.
+# It has to agree with tests/test_v515_sha_pins_lockstep.bats, because
+# scripts/preflight-check.sh runs both: the bats suite as step 3 and
+# "update-sha-pins.sh --verify" as step 8. Two different answers about one
+# state would make preflight simultaneously green and red.
+#
+# Every case here runs against a throwaway fixture repository built in
+# BATS_TEST_TMPDIR, never against the real checkout.
+#
+# Test titles are ASCII on purpose: bats on Git Bash cannot execute a test
+# whose title contains Cyrillic - it prints "unknown test name" and the case
+# silently does not run, with no "not ok" line anywhere (see MyAI-ln09).
+
+setup() {
+    ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    FIX="$BATS_TEST_TMPDIR/fixture"
+    mkdir -p "$FIX/scripts"
+    cp "$ROOT/scripts/update-sha-pins.sh" "$FIX/scripts/"
+
+    _helper awg_common.sh
+    _helper manage_amneziawg.sh
+    _helper awg_common_en.sh
+    _helper manage_amneziawg_en.sh
+    _installer install_amneziawg.sh awg_common.sh manage_amneziawg.sh
+    _installer install_amneziawg_en.sh awg_common_en.sh manage_amneziawg_en.sh
+
+    _git init -q
+    _git add -A
+    _git commit -qm initial
+}
+
+_helper() {
+    printf '#!/usr/bin/env bash\n# %s at the tag\n' "$1" > "$FIX/$1"
+}
+
+_installer() {
+    {
+        printf '#!/usr/bin/env bash\n'
+        printf 'SCRIPT_VERSION="1.0.0"\n'
+        printf 'COMMON_SCRIPT_SHA256="%s"\n' "$(_sha "$2")"
+        printf 'MANAGE_SCRIPT_SHA256="%s"\n' "$(_sha "$3")"
+    } > "$FIX/$1"
+}
+
+_sha() { sha256sum "$FIX/$1" | cut -d' ' -f1; }
+
+_git() { git -C "$FIX" -c user.name=t -c user.email=t@t "$@"; }
+
+_pin() { grep -oP '^'"$2"'_SCRIPT_SHA256="\K[0-9a-f]{64}' "$FIX/$1"; }
+
+_run_pins() { ( cd "$FIX" && bash scripts/update-sha-pins.sh "$@" 2>&1 ); }
+
+# Edit a helper AFTER the tag, so tree bytes and tag bytes differ.
+_edit_helper_after_tag() { printf '# edited on main\n' >> "$FIX/awg_common.sh"; }
+
+@test "pins: tag exists and pins match it - green, and says the tag was used" {
+    _git tag v1.0.0
+    _edit_helper_after_tag
+    run _run_pins --verify
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"tag v1.0.0"* ]]
+    [[ "$output" != *"worktree"* ]]
+}
+
+@test "pins: recomputed from the tree while the tag exists - red" {
+    _git tag v1.0.0
+    _edit_helper_after_tag
+    # The dangerous state: an installer shipped like this would refuse the
+    # download it is supposed to accept.
+    sed -i "s|^COMMON_SCRIPT_SHA256=.*|COMMON_SCRIPT_SHA256=\"$(_sha awg_common.sh)\"|" \
+        "$FIX/install_amneziawg.sh"
+    run _run_pins --verify
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"MISMATCH"* ]]
+}
+
+@test "pins: no tag for this version - writes from the tree, then is idempotent" {
+    _git tag v0.9.0
+    _edit_helper_after_tag
+    run _run_pins
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"UPDATE"* ]]
+    [ "$(_pin install_amneziawg.sh COMMON)" = "$(_sha awg_common.sh)" ]
+
+    run _run_pins
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"UPDATE"* ]]
+}
+
+@test "pins: a corrupted pin is repaired with the TAG bytes, not the tree bytes" {
+    _git tag v1.0.0
+    tagged=$(_sha awg_common.sh)
+    _edit_helper_after_tag
+    sed -i 's|^COMMON_SCRIPT_SHA256=.*|COMMON_SCRIPT_SHA256="'"$(printf '0%.0s' {1..64})"'"|' \
+        "$FIX/install_amneziawg.sh"
+    run _run_pins
+    [ "$status" -eq 0 ]
+    [ "$(_pin install_amneziawg.sh COMMON)" = "$tagged" ]
+    [ "$(_pin install_amneziawg.sh COMMON)" != "$(_sha awg_common.sh)" ]
+}
+
+@test "pins: a checkout with no tags fails, and names the tags as the reason" {
+    run _run_pins --verify
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"нет ни одного тега"* ]]
+    # The reason must not be shadowed by a second, invented one: sha256 was
+    # never computed here, so claiming it could not be computed sends the
+    # reader after the wrong thing.
+    [[ "$output" != *"не удалось вычислить sha256"* ]]
+}
+
+@test "pins: tags exist but not this version's - falls back to the tree OUT LOUD" {
+    _git tag v0.9.0
+    run _run_pins --verify
+    [ "$status" -eq 0 ]
+    # Silence here would be the whole defect: the weaker comparison must be
+    # distinguishable from the contract one.
+    [[ "$output" == *"worktree"* ]]
+    [[ "$output" == *"git fetch --tags --force"* ]]
+}
+
+@test "pins: helper missing at the tag - fails and leaves the pins alone" {
+    _git rm -q awg_common.sh
+    _git commit -qm "drop helper"
+    _git tag v1.0.0
+    _git checkout -q HEAD~1 -- awg_common.sh
+    before=$(_pin install_amneziawg.sh COMMON)
+    run _run_pins
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"не удалось прочитать v1.0.0:awg_common.sh"* ]]
+    [ "$(_pin install_amneziawg.sh COMMON)" = "$before" ]
+}

--- a/tests/test_v515_sha_pins_lockstep.bats
+++ b/tests/test_v515_sha_pins_lockstep.bats
@@ -1,53 +1,158 @@
 #!/usr/bin/env bats
-# SHA256 pin lockstep test (5.15.x line).
+# SHA256 pin lockstep test.
 #
-# The installers (install_amneziawg.sh / install_amneziawg_en.sh) download the
-# helper scripts over the network and verify them against hardcoded pins
-# (COMMON_SCRIPT_SHA256 / MANAGE_SCRIPT_SHA256). If any pin drifts from the
-# actual file hash, secure-download refuses the install. The existing
-# "SCRIPT_VERSION is consistent" test only compares version strings, not the
-# pins, so a partial sequential bump could ship a broken installer.
+# The installers download the helper scripts over the network and verify them
+# against hardcoded pins (COMMON_SCRIPT_SHA256 / MANAGE_SCRIPT_SHA256). By
+# default the URL they download from is
 #
-# This test computes the real sha256 of all four helper scripts and asserts
-# each of the four pinned values matches. Keep it green before any tag push;
-# scripts/update-sha-pins.sh --verify provides the same gate for CI.
+#     https://raw.githubusercontent.com/<repo>/${AWG_BRANCH}/<helper>
+#     AWG_BRANCH="${AWG_BRANCH:-v${SCRIPT_VERSION}}"
+#
+# so with AWG_BRANCH unset the bytes an end user receives are the bytes of the
+# helper AT THE TAG v$SCRIPT_VERSION, not the bytes in the working tree. With
+# AWG_BRANCH overridden the installer does not merely fetch from somewhere
+# else: verify_sha256() skips the pin check altogether and only warns. The pin
+# therefore governs the default path, which is the one users take.
+#
+# Comparing a pin against the neighbouring file is only a proxy for that
+# contract, and the proxy holds only while the tree happens to equal the tag.
+# It was wrong in both directions:
+#   - it went red on main after a cosmetic commit that touched a helper without
+#     a version bump, even though every published installer was still correct;
+#   - it stayed green when the pins were recomputed from the tree while the tag
+#     already existed. An installer shipped with such pins would refuse the
+#     download it is supposed to accept.
+#
+# So: if the tag for this installer's SCRIPT_VERSION exists, compare the pin
+# with the helper's bytes at that tag. If it does not exist, compare with the
+# working tree and say so out loud.
+#
+# KNOWN LIMIT, stated because a silent one would be worse: the local tag set is
+# taken as the truth. A checkout that has simply not fetched v$SCRIPT_VERSION
+# (shallow, --no-tags, a fork made before the tag), or whose tag moved under
+# "git tag -f", is indistinguishable here from an honest release in
+# preparation, and falls back to the tree comparison. Only a checkout with NO
+# tags at all is rejected outright. That fallback announces itself on TAP
+# output, so a run that checked the weaker thing can be told apart from a run
+# that checked the contract.
 
-# ---------- RU installer pins ----------
+setup() {
+    ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+}
 
-@test "RU installer COMMON pin matches awg_common.sh" {
-    actual=$(sha256sum "$BATS_TEST_DIRNAME/../awg_common.sh" | cut -d' ' -f1)
-    pinned=$(grep -oP 'COMMON_SCRIPT_SHA256="\K[0-9a-f]{64}' "$BATS_TEST_DIRNAME/../install_amneziawg.sh")
-    [ "$actual" = "$pinned" ] || {
-        echo "RU COMMON pin mismatch: pinned=$pinned actual=$actual (awg_common.sh)" >&2
+# Expected sha for a helper, resolved against whatever the installer will
+# really download. Prints the sha; on any inability to decide, prints nothing
+# and returns non-zero, because "could not check" must never read as "passed".
+_expected_sha() {
+    local installer="$1" helper="$2" ver tag
+    ver=$(grep -oP 'SCRIPT_VERSION="\K[0-9.]+' "$ROOT/$installer" | head -1)
+    if [ -z "$ver" ]; then
+        echo "cannot read SCRIPT_VERSION from $installer" >&2
+        return 1
+    fi
+    tag="v$ver"
+
+    if ! git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+        echo "not a git checkout: cannot resolve $tag, refusing to guess" >&2
+        return 1
+    fi
+
+    # A checkout with no tags at all is an environment fault, not the
+    # "tag not pushed yet" state. Without this the test would quietly
+    # degrade to the old tree comparison in CI (actions/checkout fetches
+    # no tags by default) and its result would mean nothing.
+    if [ -z "$(git -C "$ROOT" tag --list | head -1)" ]; then
+        echo "this checkout has no tags at all - fetch them (fetch-depth: 0 or fetch-tags: true)" >&2
+        return 1
+    fi
+
+    if git -C "$ROOT" rev-parse -q --verify "refs/tags/$tag" >/dev/null 2>&1; then
+        local tmp sha
+        tmp="$(mktemp)" || return 1
+        # Not "git show | sha256sum": on empty output that pipeline cheerfully
+        # hashes the empty input into 64 valid hex characters, which would sail
+        # through every length check and look like a real expected value. And
+        # not "$(git show)" either: command substitution strips trailing
+        # newlines and would change the hash.
+        if ! git -C "$ROOT" show "refs/tags/$tag:$helper" > "$tmp" 2>/dev/null; then
+            rm -f "$tmp"
+            # The cause is deliberately not named: a missing file at the tag, a
+            # corrupt object and an unfetched shallow checkout all land here.
+            echo "cannot read $tag:$helper" >&2
+            return 1
+        fi
+        sha="$(sha256sum "$tmp" | cut -d' ' -f1)"
+        rm -f "$tmp"
+        if [[ ! "$sha" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "unusable sha for $tag:$helper" >&2
+            return 1
+        fi
+        printf '%s tag %s' "$sha" "$tag"
+        return 0
+    fi
+
+    # Release in preparation, or a checkout that never fetched the tag - see
+    # KNOWN LIMIT above. Announced, not assumed silently.
+    printf '%s worktree' "$(sha256sum "$ROOT/$helper" | cut -d' ' -f1)"
+}
+
+# A pin must occur exactly once. Two occurrences are an ambiguity, not a
+# detail: bash applies the LAST assignment when it sources the installer,
+# while grep piped into head would report the first.
+_pinned_sha() {
+    local hits
+    hits=$(grep -cP '^'"$2"'_SCRIPT_SHA256="[0-9a-f]{64}"' "$ROOT/$1")
+    if [ "$hits" != "1" ]; then
+        echo "$2 pin occurs $hits times in $1 - bash would apply the last" >&2
+        return 1
+    fi
+    grep -oP '^'"$2"'_SCRIPT_SHA256="\K[0-9a-f]{64}' "$ROOT/$1"
+}
+
+_check_pin() {
+    local installer="$1" kind="$2" helper="$3" line expected src pinned
+    line=$(_expected_sha "$installer" "$helper") || {
+        echo "$kind pin for $helper NOT CHECKED (see reason above)" >&2
+        false
+        return
+    }
+    read -r expected src <<< "$line"
+    # Say which of the two comparisons actually ran. A green run that silently
+    # used the weaker one is precisely what this file exists to prevent.
+    echo "# $installer $kind: checked against $src" >&3
+    pinned=$(_pinned_sha "$installer" "$kind") || {
+        echo "$kind pin for $helper NOT CHECKED (see reason above)" >&2
+        false
+        return
+    }
+    [ -n "$expected" ] && [ -n "$pinned" ] || {
+        echo "$kind pin for $helper NOT CHECKED: empty value (expected='$expected' pinned='$pinned')" >&2
+        false
+        return
+    }
+    [ "$expected" = "$pinned" ] || {
+        echo "$installer $kind pin mismatch for $helper: pinned=$pinned expected=$expected" >&2
+        echo "  run scripts/update-sha-pins.sh after the version headers are final" >&2
         false
     }
 }
 
-@test "RU installer MANAGE pin matches manage_amneziawg.sh" {
-    actual=$(sha256sum "$BATS_TEST_DIRNAME/../manage_amneziawg.sh" | cut -d' ' -f1)
-    pinned=$(grep -oP 'MANAGE_SCRIPT_SHA256="\K[0-9a-f]{64}' "$BATS_TEST_DIRNAME/../install_amneziawg.sh")
-    [ "$actual" = "$pinned" ] || {
-        echo "RU MANAGE pin mismatch: pinned=$pinned actual=$actual (manage_amneziawg.sh)" >&2
-        false
-    }
+# ---------- RU installer pins ----------
+
+@test "RU installer COMMON pin matches awg_common.sh as published" {
+    _check_pin install_amneziawg.sh COMMON awg_common.sh
+}
+
+@test "RU installer MANAGE pin matches manage_amneziawg.sh as published" {
+    _check_pin install_amneziawg.sh MANAGE manage_amneziawg.sh
 }
 
 # ---------- EN installer pins ----------
 
-@test "EN installer COMMON pin matches awg_common_en.sh" {
-    actual=$(sha256sum "$BATS_TEST_DIRNAME/../awg_common_en.sh" | cut -d' ' -f1)
-    pinned=$(grep -oP 'COMMON_SCRIPT_SHA256="\K[0-9a-f]{64}' "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh")
-    [ "$actual" = "$pinned" ] || {
-        echo "EN COMMON pin mismatch: pinned=$pinned actual=$actual (awg_common_en.sh)" >&2
-        false
-    }
+@test "EN installer COMMON pin matches awg_common_en.sh as published" {
+    _check_pin install_amneziawg_en.sh COMMON awg_common_en.sh
 }
 
-@test "EN installer MANAGE pin matches manage_amneziawg_en.sh" {
-    actual=$(sha256sum "$BATS_TEST_DIRNAME/../manage_amneziawg_en.sh" | cut -d' ' -f1)
-    pinned=$(grep -oP 'MANAGE_SCRIPT_SHA256="\K[0-9a-f]{64}' "$BATS_TEST_DIRNAME/../install_amneziawg_en.sh")
-    [ "$actual" = "$pinned" ] || {
-        echo "EN MANAGE pin mismatch: pinned=$pinned actual=$actual (manage_amneziawg_en.sh)" >&2
-        false
-    }
+@test "EN installer MANAGE pin matches manage_amneziawg_en.sh as published" {
+    _check_pin install_amneziawg_en.sh MANAGE manage_amneziawg_en.sh
 }


### PR DESCRIPTION
## Summary

The SHA pin lockstep test compared each pin with the helper file next to it in
the working tree. The installers do not download that file: they fetch from
`raw.githubusercontent.com/<repo>/${AWG_BRANCH}/<helper>` with `AWG_BRANCH`
defaulting to `v$SCRIPT_VERSION`, so the pin's source of truth is the helper's
bytes **at the tag**. The tree comparison is a proxy that holds only while the
tree happens to equal the tag, and it was wrong in both directions:

- **red on `main`** after a helper was touched without a version bump, although
  every published installer was correct. This is the current state of `main`
  (`9cfbf13` touched `awg_common.sh`; pins and tag agree at `0ae0980`), and it
  is what shows the failing Tests badge on the repository front page;
- **green in the one genuinely dangerous state** - pins recomputed from the tree
  while the tag already exists. An installer shipped like that refuses the
  download it is supposed to accept.

Both the test and `scripts/update-sha-pins.sh` now compare against the tag when
it exists, against the working tree when it does not, and both state which of
the two comparisons they made.

### Why `update-sha-pins.sh` moves with the test

`preflight-check.sh` runs the bats suite as step 3 and `update-sha-pins.sh
--verify` as step 8. Leaving them on different criteria would make preflight
green and red about a single state, and step 8 would keep advising a rewrite
that produces exactly what the test now forbids.

### Known limit, written down rather than hidden

Both tools read the **local** tag set. A checkout that never fetched
`v$SCRIPT_VERSION` (shallow, `--no-tags`, a fork made before the tag) or whose
tag moved under `git tag -f` is indistinguishable here from an honest release in
preparation, and falls back to the tree comparison. There is no reliable local
oracle for the difference, so the fallback announces itself instead of being
silent, `RELEASE_PROCESS.md` asks for `git fetch --tags --force` before the
preflight, and a checkout with no tags at all is rejected outright.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [x] CI/CD
- [ ] Refactoring

## What was verified

| Check | Result |
|---|---|
| Mutation runs against the changed code | 17 cases, 0 failures |
| `tests/test_sha_pin_source_of_truth.bats` against the **previous** script | 6 of 7 red, so the cases are real |
| Full `bats tests/*.bats` | plan 1432, executed 1414, 10 failures - the same 10 as before this branch, all reproduced on an untouched clone and all green in CI |
| `update-sha-pins.sh --verify` | 0, source reported as `tag v5.28.1` |
| `check-docs-consistency.sh` | 0 |
| `bash -n`, `shellcheck -s bash -S warning` | clean, including the `.bats` files |

Mutations that matter: pins recomputed from the tree while the tag lives now
turn the test red (the old test was green); a corrupted pin is repaired with the
**tag** bytes and the test goes green afterwards; a checkout with a partial tag
set announces the weaker comparison instead of passing silently; a checkout with
no tags fails with one reason rather than two, the second of which used to be
invented.

`fetch-depth: 0` was measured rather than assumed: full history 1 s and 11 MB,
`fetch-tags: true` at depth 1 also works (4.4 MB), the default brings 0 tags.
Full history matches `release.yml` and `commit-hygiene.yml`, which already use
it.

## Checklist

- [x] `bash -n` passes for all modified scripts
- [x] `shellcheck -s bash -S warning` passes
- [x] `bats tests/` passes (add a test for new behaviour)
- [x] `scripts/check-docs-consistency.sh` passes (if docs or metadata changed)
- [ ] Tested on clean Ubuntu 24.04 LTS VPS (if script changes) - not applicable, no runtime script changed
- [ ] Tested on Ubuntu 25.10/26.04 (noble fallback path, if PPA/install logic changes) - not applicable
- [ ] Tested on Debian 12/13 (if OS-specific changes) - not applicable
- [x] CHANGELOG.md **and** CHANGELOG.en.md updated, or not applicable (internal/test-only change) - not applicable, tooling and tests only
- [ ] SCRIPT_VERSION updated (if releasing new version) - not a release
- [x] SHA pins recomputed and verified (`scripts/update-sha-pins.sh --verify`) - verified, unchanged: they already equal the tag bytes
- [ ] Version badge in README.md and README.en.md updated (if version bump) - not a release
- [x] Documentation updated (if applicable)
- [x] Security-sensitive changes reviewed (no eval/source on user data, strict permissions)
- [ ] English script versions (`_en.sh`) synchronized (if Russian scripts modified) - not applicable, no runtime script changed
- [ ] Rollback tested: `--uninstall` + fresh install (if installer changes) - not applicable
- [ ] vpn:// URI generation verified (if `awg_common` changes) - not applicable

## Note on the checklist item about pins

The item above asks for pins to be recomputed when a helper changes. After this
PR that instruction is only correct inside a release, once `SCRIPT_VERSION` has
been bumped and before the tag is pushed. Between releases the correct pin is
the tag's, and it is already in place, so `update-sha-pins.sh` is a no-op there.
