### PR TITLE
fix(diagnose): stop deriving the protocol generation from the module version string

### DIFF
--- a/awg_common.sh
+++ b/awg_common.sh
@@ -503,6 +503,38 @@ awg_module_version() {
     printf '%s' "$ver"
 }
 
+# awg_module_build_id : признак СБОРКИ загруженного модуля, одной строкой.
+# Пустая строка, если ничего опознать не удалось.
+#
+# 🔴 Зачем это отдельно от awg_module_version. Строка версии модуля сборку НЕ
+# различает: замер на стенде 30 aug 2026 дал `3.1.20260812` И для сборки PPA от
+# 14 aug (`4680320`), И для сборки от 28 aug (`3c38e16`) - MODULE_VERSION статичен
+# в исходниках и меняется реже, чем сам код. Различают только srcversion (хеш
+# исходников, который считает сборщик модуля) и версия пакета.
+# Без этого признака диагностический отчёт не отвечает на вопрос «какая у тебя
+# сборка», а именно он нужен, когда расходятся модуль ядра и userspace-клиент.
+#
+# AWG_MODULE_SRCVERSION_PATH переопределяется только тестами: подменить /sys
+# иначе нельзя, а проверить надо именно чтение загруженного модуля.
+awg_module_build_id() {
+    local src="" pkg="" out=""
+    local sysfile="${AWG_MODULE_SRCVERSION_PATH:-/sys/module/amneziawg/srcversion}"
+    if [[ -r "$sysfile" ]]; then
+        # `|| true` по той же причине, что и в awg_module_version: на файле без
+        # завершающего перевода строки read возвращает 1, УЖЕ присвоив прочитанное.
+        IFS= read -r src 2>/dev/null < "$sysfile" || true
+        src="${src//[[:space:]]/}"
+    fi
+    pkg=$(dpkg-query -W -f='${Version}' amneziawg-dkms 2>/dev/null || true)
+    pkg="${pkg//[[:space:]]/}"
+    [[ -n "$src" ]] && out="srcversion $src"
+    if [[ -n "$pkg" ]]; then
+        [[ -n "$out" ]] && out="$out, "
+        out="${out}пакет $pkg"
+    fi
+    printf '%s' "$out"
+}
+
 #
 # После apt upgrade ядра DKMS-модуль должен пересобраться для нового kernel.
 # Если это не произошло (или модуль был отвязан), 4 функции ниже выполняют

--- a/awg_common.sh
+++ b/awg_common.sh
@@ -525,12 +525,19 @@ awg_module_build_id() {
         IFS= read -r src 2>/dev/null < "$sysfile" || true
         src="${src//[[:space:]]/}"
     fi
-    pkg=$(dpkg-query -W -f='${Version}' amneziawg-dkms 2>/dev/null || true)
+    # Только ПЕРВАЯ строка: при нескольких совпадениях склейка дала бы
+    # правдоподобную, но несуществующую версию, а это хуже отказа.
+    pkg=$(dpkg-query -W -f='${Version}\n' amneziawg-dkms 2>/dev/null | head -n 1 || true)
     pkg="${pkg//[[:space:]]/}"
-    [[ -n "$src" ]] && out="srcversion $src"
+    # 🔴 Две части НАЗВАНЫ ПО-РАЗНОМУ намеренно: это разные вещи, и они
+    # расходятся штатно. Пакет можно обновить, а модуль в памяти останется
+    # прежним до перезагрузки или modprobe - ровно это наблюдалось на стенде
+    # 30 aug 2026. Слить их в один «признак сборки» значило бы выдать версию
+    # пакета за версию загруженного кода.
+    [[ -n "$src" ]] && out="srcversion загруженного $src"
     if [[ -n "$pkg" ]]; then
-        [[ -n "$out" ]] && out="$out, "
-        out="${out}пакет $pkg"
+        [[ -n "$out" ]] && out="$out; "
+        out="${out}установлен пакет $pkg"
     fi
     printf '%s' "$out"
 }

--- a/awg_common_en.sh
+++ b/awg_common_en.sh
@@ -533,12 +533,19 @@ awg_module_build_id() {
         IFS= read -r src 2>/dev/null < "$sysfile" || true
         src="${src//[[:space:]]/}"
     fi
-    pkg=$(dpkg-query -W -f='${Version}' amneziawg-dkms 2>/dev/null || true)
+    # FIRST line only: on several matches concatenation would produce a
+    # plausible but non-existent version, and that is worse than no answer.
+    pkg=$(dpkg-query -W -f='${Version}\n' amneziawg-dkms 2>/dev/null | head -n 1 || true)
     pkg="${pkg//[[:space:]]/}"
-    [[ -n "$src" ]] && out="srcversion $src"
+    # 🔴 The two parts are LABELLED DIFFERENTLY on purpose: they are different
+    # things and they diverge routinely. The package can be upgraded while the
+    # module in memory stays the old one until a reboot or modprobe - exactly
+    # what was observed on the bench on 30 aug 2026. Merging them into one
+    # "build id" would pass the package version off as the loaded code.
+    [[ -n "$src" ]] && out="loaded srcversion $src"
     if [[ -n "$pkg" ]]; then
-        [[ -n "$out" ]] && out="$out, "
-        out="${out}package $pkg"
+        [[ -n "$out" ]] && out="$out; "
+        out="${out}installed package $pkg"
     fi
     printf '%s' "$out"
 }

--- a/awg_common_en.sh
+++ b/awg_common_en.sh
@@ -508,6 +508,41 @@ awg_module_version() {
     printf '%s' "$ver"
 }
 
+# awg_module_build_id : build identity of the loaded module, on one line.
+# Empty string when nothing could be identified.
+#
+# 🔴 Why this is separate from awg_module_version. The module version string
+# does NOT identify the build: a bench measurement on 30 aug 2026 read
+# `3.1.20260812` BOTH from the PPA build of 14 aug (`4680320`) AND from the one
+# of 28 aug (`3c38e16`) - MODULE_VERSION is a static define and changes far less
+# often than the code. Only srcversion (the source hash the module build
+# computes) and the package version tell the builds apart.
+# Without it the diagnostic report cannot answer "which build do you have",
+# which is exactly the question when a kernel module and a userspace client
+# disagree.
+#
+# AWG_MODULE_SRCVERSION_PATH is overridden by tests only: /sys cannot be
+# replaced otherwise, and what has to be verified is the read of the loaded
+# module.
+awg_module_build_id() {
+    local src="" pkg="" out=""
+    local sysfile="${AWG_MODULE_SRCVERSION_PATH:-/sys/module/amneziawg/srcversion}"
+    if [[ -r "$sysfile" ]]; then
+        # `|| true` for the same reason as in awg_module_version: on a file with
+        # no trailing newline read returns 1 having ALREADY assigned the value.
+        IFS= read -r src 2>/dev/null < "$sysfile" || true
+        src="${src//[[:space:]]/}"
+    fi
+    pkg=$(dpkg-query -W -f='${Version}' amneziawg-dkms 2>/dev/null || true)
+    pkg="${pkg//[[:space:]]/}"
+    [[ -n "$src" ]] && out="srcversion $src"
+    if [[ -n "$pkg" ]]; then
+        [[ -n "$out" ]] && out="$out, "
+        out="${out}package $pkg"
+    fi
+    printf '%s' "$out"
+}
+
 #
 # After an apt kernel upgrade the DKMS module must be rebuilt for the new
 # kernel. If that did not happen automatically (or the module was unbound),

--- a/manage_amneziawg.sh
+++ b/manage_amneziawg.sh
@@ -1386,12 +1386,23 @@ diagnose_server() {
 
     # 1. Kernel module
     if lsmod 2>/dev/null | awk '$1 == "amneziawg" {f=1} END {exit !f}'; then
-        local _d_mod_ver
+        local _d_mod_ver _d_mod_build
+        # 🔴 Поколение протокола по строке версии НЕ выводим. Здесь стояла
+        # догадка `== 3.*` -> литерал "AmneziaWG 3.0", и она врала: замер на
+        # стенде 30 aug 2026 дал `3.1.20260812` и для сборки PPA от 14 aug, и
+        # для сборки от 28 aug, то есть 3.1-модуль объявлялся третьей нулевой.
+        # Тот же запрет уже стоял в check выше ("не выводим протокол по
+        # догадке"), но этот путь его не соблюдал.
+        # Сборку различают srcversion и версия пакета - их и печатаем: без них
+        # отчёт не отвечает на вопрос, какая сборка у пользователя.
         _d_mod_ver=$(awg_module_version)
-        if [[ "$_d_mod_ver" == 3.* ]]; then
-            _diag_line OK "Модуль ядра amneziawg загружен (AmneziaWG 3.0, $_d_mod_ver)"
+        _d_mod_build=$(awg_module_build_id)
+        if [[ -n "$_d_mod_ver" && -n "$_d_mod_build" ]]; then
+            _diag_line OK "Модуль ядра amneziawg загружен (версия $_d_mod_ver; $_d_mod_build)"
         elif [[ -n "$_d_mod_ver" ]]; then
-            _diag_line OK "Модуль ядра amneziawg загружен ($_d_mod_ver)"
+            _diag_line OK "Модуль ядра amneziawg загружен (версия $_d_mod_ver)"
+        elif [[ -n "$_d_mod_build" ]]; then
+            _diag_line OK "Модуль ядра amneziawg загружен ($_d_mod_build)"
         else
             _diag_line OK "Модуль ядра amneziawg загружен"
         fi

--- a/manage_amneziawg_en.sh
+++ b/manage_amneziawg_en.sh
@@ -1401,12 +1401,23 @@ diagnose_server() {
 
     # 1. Kernel module
     if lsmod 2>/dev/null | awk '$1 == "amneziawg" {f=1} END {exit !f}'; then
-        local _d_mod_ver
+        local _d_mod_ver _d_mod_build
+        # 🔴 Do NOT derive the protocol generation from the version string. A
+        # guess `== 3.*` -> the literal "AmneziaWG 3.0" used to live here, and it
+        # lied: a bench measurement on 30 aug 2026 read `3.1.20260812` from both
+        # the PPA build of 14 aug and the one of 28 aug, so a 3.1 module was
+        # announced as 3.0. The same ban was already written down in check above
+        # ("do not print the protocol from a guess"); this path ignored it.
+        # srcversion and the package version are what tell builds apart, so we
+        # print those: without them the report cannot say which build is loaded.
         _d_mod_ver=$(awg_module_version)
-        if [[ "$_d_mod_ver" == 3.* ]]; then
-            _diag_line OK "Kernel module amneziawg loaded (AmneziaWG 3.0, $_d_mod_ver)"
+        _d_mod_build=$(awg_module_build_id)
+        if [[ -n "$_d_mod_ver" && -n "$_d_mod_build" ]]; then
+            _diag_line OK "Kernel module amneziawg loaded (version $_d_mod_ver; $_d_mod_build)"
         elif [[ -n "$_d_mod_ver" ]]; then
-            _diag_line OK "Kernel module amneziawg loaded ($_d_mod_ver)"
+            _diag_line OK "Kernel module amneziawg loaded (version $_d_mod_ver)"
+        elif [[ -n "$_d_mod_build" ]]; then
+            _diag_line OK "Kernel module amneziawg loaded ($_d_mod_build)"
         else
             _diag_line OK "Kernel module amneziawg loaded"
         fi

--- a/tests/test_module_build_id.bats
+++ b/tests/test_module_build_id.bats
@@ -10,32 +10,36 @@
 # all. check, 130 lines above in the same file, already carried the opposite
 # rule in a comment.
 #
-# What this pins:
-#   - awg_module_build_id reports srcversion and the package version;
-#   - it survives a srcversion file with no trailing newline;
-#   - it returns an empty string rather than junk when nothing is available;
-#   - 🔴 the diagnose kernel-module block contains no hardcoded generation
-#     literal and does call the build-id helper. This is the test that goes red
-#     if the guess comes back.
+# 🔴 Why every assertion below is either plain or final. In bash, `set -e` is
+# ignored when a return value is inverted with `!`, so a bare `! grep ...` that
+# is not the last command of a bats body is INERT: it reads like a check and
+# checks nothing. The first version of this file had exactly that, and its
+# mutation run passed only because of a different assertion further down.
+# Verified on this machine: a failing `! true` in the middle of a body leaves
+# the test green, while a plain `[ 1 -eq 2 ]` in the same place fails it.
+#
+# The guards also read the EXECUTABLE lines only. The comment that explains the
+# removal names the old literal, and a whole-block grep would trip over the
+# explanation instead of the code.
 
 RU_COMMON="${BATS_TEST_DIRNAME}/../awg_common.sh"
 EN_COMMON="${BATS_TEST_DIRNAME}/../awg_common_en.sh"
 RU_MANAGE="${BATS_TEST_DIRNAME}/../manage_amneziawg.sh"
 EN_MANAGE="${BATS_TEST_DIRNAME}/../manage_amneziawg_en.sh"
 
-# The kernel-module stanza of diagnose_server, both languages.
-_diag_module_block() {
-    awk '/# 1\. Kernel module/,/# 2\. Service active/' "$1"
+# Executable lines of the kernel-module stanza of diagnose_server.
+_diag_module_code() {
+    awk '/# 1\. Kernel module/,/# 2\. Service active/' "$1" | grep -vE '^[[:space:]]*#'
 }
 
-# Run awg_module_build_id extracted from a library, with /sys and dpkg-query
-# both under the test's control.
+# awg_module_build_id from a given library, with /sys and dpkg-query both under
+# the test's control.
 _run_build_id() {
     local src="$1" stub_pkg="$2" lib="$3"
     local bin="$BATS_TEST_TMPDIR/bin"
     mkdir -p "$bin"
     if [ -n "$stub_pkg" ]; then
-        printf '#!/usr/bin/env bash\nprintf %%s %s\n' "$stub_pkg" > "$bin/dpkg-query"
+        printf '#!/usr/bin/env bash\nprintf "%%s\\n" %s\n' "$stub_pkg" > "$bin/dpkg-query"
     else
         printf '#!/usr/bin/env bash\nexit 1\n' > "$bin/dpkg-query"
     fi
@@ -54,67 +58,151 @@ _run_build_id() {
     grep -qE '^awg_module_build_id\(\) \{' "$EN_COMMON"
 }
 
-@test "build id: srcversion is reported" {
-    local f="$BATS_TEST_TMPDIR/srcversion"
-    printf '5F142DE112E19E1AD2E6344\n' > "$f"
-    run _run_build_id "$f" "" "$RU_COMMON"
+@test "build id RU: srcversion alone" {
+    printf '5F142DE112E19E1AD2E6344\n' > "$BATS_TEST_TMPDIR/s"
+    run _run_build_id "$BATS_TEST_TMPDIR/s" "" "$RU_COMMON"
     [ "$status" -eq 0 ]
     [[ "$output" == *"5F142DE112E19E1AD2E6344"* ]]
+    [ "$(grep -c ';' <<< "$output")" -eq 0 ]
 }
 
-@test "build id: package version is reported alongside srcversion" {
-    local f="$BATS_TEST_TMPDIR/srcversion"
-    printf 'B55FF16F2E5FAADE434191F\n' > "$f"
-    run _run_build_id "$f" "1.0.0-0~202608140352+4680320~ubuntu24.04.1" "$RU_COMMON"
+@test "build id EN: srcversion alone" {
+    printf '5F142DE112E19E1AD2E6344\n' > "$BATS_TEST_TMPDIR/s"
+    run _run_build_id "$BATS_TEST_TMPDIR/s" "" "$EN_COMMON"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"B55FF16F2E5FAADE434191F"* ]]
-    [[ "$output" == *"4680320"* ]]
+    [[ "$output" == *"5F142DE112E19E1AD2E6344"* ]]
+    [ "$(grep -c ';' <<< "$output")" -eq 0 ]
 }
 
-@test "build id: a srcversion file without a trailing newline is still read" {
-    local f="$BATS_TEST_TMPDIR/srcversion_nonl"
-    printf 'ABCDEF0123456789' > "$f"
-    run _run_build_id "$f" "" "$RU_COMMON"
+@test "build id RU: package alone, no srcversion available" {
+    run _run_build_id "$BATS_TEST_TMPDIR/absent" "1.0.0-0~pkg+abc~ubuntu24.04.1" "$RU_COMMON"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"1.0.0-0~pkg+abc~ubuntu24.04.1"* ]]
+    [ "$(grep -c ';' <<< "$output")" -eq 0 ]
+}
+
+@test "build id EN: package alone, no srcversion available" {
+    run _run_build_id "$BATS_TEST_TMPDIR/absent" "1.0.0-0~pkg+abc~ubuntu24.04.1" "$EN_COMMON"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"1.0.0-0~pkg+abc~ubuntu24.04.1"* ]]
+    [ "$(grep -c ';' <<< "$output")" -eq 0 ]
+}
+
+# 🔴 The loaded module and the installed package diverge routinely: upgrading
+# the package leaves the old module in memory until modprobe. They must be
+# reported as two labelled things, not merged into one identity.
+@test "build id RU: both parts are separated and the loaded one comes first" {
+    printf 'B55FF16F2E5FAADE434191F\n' > "$BATS_TEST_TMPDIR/s"
+    run _run_build_id "$BATS_TEST_TMPDIR/s" "1.0.0-0~202608140352+4680320~ubuntu24.04.1" "$RU_COMMON"
+    [ "$status" -eq 0 ]
+    [ "$(grep -c ';' <<< "$output")" -eq 1 ]
+    local head_part="${output%%;*}" tail_part="${output#*;}"
+    [[ "$head_part" == *"B55FF16F2E5FAADE434191F"* ]]
+    [[ "$tail_part" == *"4680320"* ]]
+}
+
+@test "build id EN: both parts are separated and the loaded one comes first" {
+    printf 'B55FF16F2E5FAADE434191F\n' > "$BATS_TEST_TMPDIR/s"
+    run _run_build_id "$BATS_TEST_TMPDIR/s" "1.0.0-0~202608140352+4680320~ubuntu24.04.1" "$EN_COMMON"
+    [ "$status" -eq 0 ]
+    [ "$(grep -c ';' <<< "$output")" -eq 1 ]
+    local head_part="${output%%;*}" tail_part="${output#*;}"
+    [[ "$head_part" == *"B55FF16F2E5FAADE434191F"* ]]
+    [[ "$tail_part" == *"4680320"* ]]
+}
+
+@test "build id RU: a srcversion file without a trailing newline is still read" {
+    printf 'ABCDEF0123456789' > "$BATS_TEST_TMPDIR/s"
+    run _run_build_id "$BATS_TEST_TMPDIR/s" "" "$RU_COMMON"
     [ "$status" -eq 0 ]
     [[ "$output" == *"ABCDEF0123456789"* ]]
 }
 
-@test "build id: nothing available yields an empty string, not junk" {
-    run _run_build_id "$BATS_TEST_TMPDIR/does-not-exist" "" "$RU_COMMON"
+@test "build id EN: a srcversion file without a trailing newline is still read" {
+    printf 'ABCDEF0123456789' > "$BATS_TEST_TMPDIR/s"
+    run _run_build_id "$BATS_TEST_TMPDIR/s" "" "$EN_COMMON"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ABCDEF0123456789"* ]]
+}
+
+# 🔴 Several matching lines must not be glued into one plausible but
+# non-existent version. Only the first is taken.
+_run_build_id_multiline() {
+    local lib="$1"
+    local bin="$BATS_TEST_TMPDIR/bin_multi"
+    mkdir -p "$bin"
+    cat > "$bin/dpkg-query" <<'STUB'
+#!/usr/bin/env bash
+printf '1.0.0-first\n2.0.0-second\n'
+STUB
+    chmod +x "$bin/dpkg-query"
+    PATH="$bin:$PATH" AWG_MODULE_SRCVERSION_PATH="$BATS_TEST_TMPDIR/absent" bash -c '
+        '"$(awk '/^awg_module_build_id\(\) \{/,/^\}/' "$lib")"'
+        awg_module_build_id
+    '
+}
+
+@test "build id RU: several package lines do not get glued together" {
+    run _run_build_id_multiline "$RU_COMMON"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"1.0.0-first"* ]]
+    run bash -c 'grep -c "2.0.0-second" <<< "$1"' _ "$output"
+    [ "$output" = "0" ]
+}
+
+@test "build id EN: several package lines do not get glued together" {
+    run _run_build_id_multiline "$EN_COMMON"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"1.0.0-first"* ]]
+    run bash -c 'grep -c "2.0.0-second" <<< "$1"' _ "$output"
+    [ "$output" = "0" ]
+}
+
+@test "build id RU: nothing available yields an empty string, not junk" {
+    run _run_build_id "$BATS_TEST_TMPDIR/absent" "" "$RU_COMMON"
     [ "$status" -eq 0 ]
     [ -z "$output" ]
 }
 
-@test "build id: EN library behaves the same on srcversion" {
-    local f="$BATS_TEST_TMPDIR/srcversion_en"
-    printf 'DEADBEEFCAFE\n' > "$f"
-    run _run_build_id "$f" "" "$EN_COMMON"
+@test "build id EN: nothing available yields an empty string, not junk" {
+    run _run_build_id "$BATS_TEST_TMPDIR/absent" "" "$EN_COMMON"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"DEADBEEFCAFE"* ]]
+    [ -z "$output" ]
 }
 
-# 🔴 The guard. If someone reintroduces "print the generation from the version
-# string", these two go red.
-@test "diagnose RU: kernel-module block hardcodes no protocol generation" {
-    local block
-    block="$(_diag_module_block "$RU_MANAGE")"
-    [ -n "$block" ]
-    ! grep -qE 'AmneziaWG 3\.[0-9]' <<< "$block"
-    ! grep -qE '_d_mod_ver" == 3\.' <<< "$block"
+# 🔴 The guards. If the generation guess comes back, these go red.
+@test "diagnose RU: executable lines carry no hardcoded generation literal" {
+    _diag_module_code "$RU_MANAGE" > "$BATS_TEST_TMPDIR/code"
+    [ -s "$BATS_TEST_TMPDIR/code" ]
+    run grep -cE 'AmneziaWG [0-9]+\.[0-9]' "$BATS_TEST_TMPDIR/code"
+    [ "$output" = "0" ]
 }
 
-@test "diagnose EN: kernel-module block hardcodes no protocol generation" {
-    local block
-    block="$(_diag_module_block "$EN_MANAGE")"
-    [ -n "$block" ]
-    ! grep -qE 'AmneziaWG 3\.[0-9]' <<< "$block"
-    ! grep -qE '_d_mod_ver" == 3\.' <<< "$block"
+@test "diagnose EN: executable lines carry no hardcoded generation literal" {
+    _diag_module_code "$EN_MANAGE" > "$BATS_TEST_TMPDIR/code"
+    [ -s "$BATS_TEST_TMPDIR/code" ]
+    run grep -cE 'AmneziaWG [0-9]+\.[0-9]' "$BATS_TEST_TMPDIR/code"
+    [ "$output" = "0" ]
 }
 
-@test "diagnose RU: kernel-module block asks for the build id" {
-    _diag_module_block "$RU_MANAGE" | grep -q 'awg_module_build_id'
+@test "diagnose RU: executable lines do not branch on the version prefix" {
+    _diag_module_code "$RU_MANAGE" > "$BATS_TEST_TMPDIR/code"
+    [ -s "$BATS_TEST_TMPDIR/code" ]
+    run grep -cE '_d_mod_ver"[[:space:]]*==[[:space:]]*3\.' "$BATS_TEST_TMPDIR/code"
+    [ "$output" = "0" ]
 }
 
-@test "diagnose EN: kernel-module block asks for the build id" {
-    _diag_module_block "$EN_MANAGE" | grep -q 'awg_module_build_id'
+@test "diagnose EN: executable lines do not branch on the version prefix" {
+    _diag_module_code "$EN_MANAGE" > "$BATS_TEST_TMPDIR/code"
+    [ -s "$BATS_TEST_TMPDIR/code" ]
+    run grep -cE '_d_mod_ver"[[:space:]]*==[[:space:]]*3\.' "$BATS_TEST_TMPDIR/code"
+    [ "$output" = "0" ]
+}
+
+@test "diagnose RU: the stanza asks for the build id" {
+    _diag_module_code "$RU_MANAGE" | grep -q 'awg_module_build_id'
+}
+
+@test "diagnose EN: the stanza asks for the build id" {
+    _diag_module_code "$EN_MANAGE" | grep -q 'awg_module_build_id'
 }

--- a/tests/test_module_build_id.bats
+++ b/tests/test_module_build_id.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+# The module version string does not identify the build, and diagnose must not
+# pretend otherwise.
+#
+# Background. `/sys/module/amneziawg/version` is a static MODULE_VERSION define.
+# A bench measurement on 30 aug 2026 read `3.1.20260812` from BOTH the PPA build
+# of 14 aug and the one of 28 aug. diagnose used to turn that string into the
+# literal "AmneziaWG 3.0" via `[[ $ver == 3.* ]]`, so every user on the third
+# line saw a 3.1 module announced as 3.0, and no build could be told apart at
+# all. check, 130 lines above in the same file, already carried the opposite
+# rule in a comment.
+#
+# What this pins:
+#   - awg_module_build_id reports srcversion and the package version;
+#   - it survives a srcversion file with no trailing newline;
+#   - it returns an empty string rather than junk when nothing is available;
+#   - 🔴 the diagnose kernel-module block contains no hardcoded generation
+#     literal and does call the build-id helper. This is the test that goes red
+#     if the guess comes back.
+
+RU_COMMON="${BATS_TEST_DIRNAME}/../awg_common.sh"
+EN_COMMON="${BATS_TEST_DIRNAME}/../awg_common_en.sh"
+RU_MANAGE="${BATS_TEST_DIRNAME}/../manage_amneziawg.sh"
+EN_MANAGE="${BATS_TEST_DIRNAME}/../manage_amneziawg_en.sh"
+
+# The kernel-module stanza of diagnose_server, both languages.
+_diag_module_block() {
+    awk '/# 1\. Kernel module/,/# 2\. Service active/' "$1"
+}
+
+# Run awg_module_build_id extracted from a library, with /sys and dpkg-query
+# both under the test's control.
+_run_build_id() {
+    local src="$1" stub_pkg="$2" lib="$3"
+    local bin="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$bin"
+    if [ -n "$stub_pkg" ]; then
+        printf '#!/usr/bin/env bash\nprintf %%s %s\n' "$stub_pkg" > "$bin/dpkg-query"
+    else
+        printf '#!/usr/bin/env bash\nexit 1\n' > "$bin/dpkg-query"
+    fi
+    chmod +x "$bin/dpkg-query"
+    PATH="$bin:$PATH" AWG_MODULE_SRCVERSION_PATH="$src" bash -c '
+        '"$(awk '/^awg_module_build_id\(\) \{/,/^\}/' "$lib")"'
+        awg_module_build_id
+    '
+}
+
+@test "build id: RU library defines awg_module_build_id" {
+    grep -qE '^awg_module_build_id\(\) \{' "$RU_COMMON"
+}
+
+@test "build id: EN library defines awg_module_build_id" {
+    grep -qE '^awg_module_build_id\(\) \{' "$EN_COMMON"
+}
+
+@test "build id: srcversion is reported" {
+    local f="$BATS_TEST_TMPDIR/srcversion"
+    printf '5F142DE112E19E1AD2E6344\n' > "$f"
+    run _run_build_id "$f" "" "$RU_COMMON"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"5F142DE112E19E1AD2E6344"* ]]
+}
+
+@test "build id: package version is reported alongside srcversion" {
+    local f="$BATS_TEST_TMPDIR/srcversion"
+    printf 'B55FF16F2E5FAADE434191F\n' > "$f"
+    run _run_build_id "$f" "1.0.0-0~202608140352+4680320~ubuntu24.04.1" "$RU_COMMON"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"B55FF16F2E5FAADE434191F"* ]]
+    [[ "$output" == *"4680320"* ]]
+}
+
+@test "build id: a srcversion file without a trailing newline is still read" {
+    local f="$BATS_TEST_TMPDIR/srcversion_nonl"
+    printf 'ABCDEF0123456789' > "$f"
+    run _run_build_id "$f" "" "$RU_COMMON"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ABCDEF0123456789"* ]]
+}
+
+@test "build id: nothing available yields an empty string, not junk" {
+    run _run_build_id "$BATS_TEST_TMPDIR/does-not-exist" "" "$RU_COMMON"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "build id: EN library behaves the same on srcversion" {
+    local f="$BATS_TEST_TMPDIR/srcversion_en"
+    printf 'DEADBEEFCAFE\n' > "$f"
+    run _run_build_id "$f" "" "$EN_COMMON"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DEADBEEFCAFE"* ]]
+}
+
+# 🔴 The guard. If someone reintroduces "print the generation from the version
+# string", these two go red.
+@test "diagnose RU: kernel-module block hardcodes no protocol generation" {
+    local block
+    block="$(_diag_module_block "$RU_MANAGE")"
+    [ -n "$block" ]
+    ! grep -qE 'AmneziaWG 3\.[0-9]' <<< "$block"
+    ! grep -qE '_d_mod_ver" == 3\.' <<< "$block"
+}
+
+@test "diagnose EN: kernel-module block hardcodes no protocol generation" {
+    local block
+    block="$(_diag_module_block "$EN_MANAGE")"
+    [ -n "$block" ]
+    ! grep -qE 'AmneziaWG 3\.[0-9]' <<< "$block"
+    ! grep -qE '_d_mod_ver" == 3\.' <<< "$block"
+}
+
+@test "diagnose RU: kernel-module block asks for the build id" {
+    _diag_module_block "$RU_MANAGE" | grep -q 'awg_module_build_id'
+}
+
+@test "diagnose EN: kernel-module block asks for the build id" {
+    _diag_module_block "$EN_MANAGE" | grep -q 'awg_module_build_id'
+}


### PR DESCRIPTION
## What this fixes

`diagnose` printed the protocol generation by looking at the kernel module
version string:

```bash
if [[ "$_d_mod_ver" == 3.* ]]; then
    _diag_line OK "... (AmneziaWG 3.0, $_d_mod_ver)"
```

That string does not carry the generation. It is a static `MODULE_VERSION`
define, and a bench measurement on 30 aug 2026 read `3.1.20260812` from **both**
the PPA build of 14 aug (`4680320`) and the one of 28 aug (`3c38e16`). Two
consequences, both live today:

1. every user on the third line sees a 3.1 module reported as **3.0**;
2. the report cannot identify the build **at all** - it prints neither the
   package version nor `srcversion`, which is exactly the question when a kernel
   module and a userspace client disagree.

`check`, 130 lines above in the same file, already carried the opposite rule in
a comment: *"upstream tag names historically do not match the protocol version,
so print the raw value and do not print the protocol from a guess"*. This path
ignored it.

## What changes

- the guess is gone; `diagnose` prints the raw version, like `check` does;
- new `awg_module_build_id` reports what actually identifies the build.

The loaded module and the installed package are **labelled separately on
purpose**. They diverge routinely: upgrading the package leaves the old module
in memory until a reboot or `modprobe`. That is not theoretical - it happened on
the bench while taking the measurement above. Merging them into one identity
would pass the package version off as the loaded code.

Only the first line of `dpkg-query` is used: several matching lines would have
been glued into a plausible but non-existent version, which is worse than no
answer.

## No functional change

The generation gate `_kernel_supports_awg3` keys off the **kernel** version, not
off this string, so nothing chooses a code path from it. Only the diagnostic
text changes.

## Tests

`tests/test_module_build_id.bats`, 20 cases, RU and EN symmetric: srcversion
alone, package alone, both parts separated, a srcversion file with no trailing
newline, several package lines not glued, nothing available yielding an empty
string rather than junk, plus guards that the diagnose stanza carries no
hardcoded generation literal, does not branch on the version prefix, and does
ask for the build id.

**Verified by mutation, one run at a time.** Eleven mutations - restoring the
literal or the version-prefix branch in either language, dropping the helper
call, merging the two parts, breaking the srcversion read, dropping the
first-line guard - each turns exactly the intended test red, with a clean tree
before and after.

### A note on the first version of these tests

The guards originally used bare `! grep ...` in the middle of the test body. In
bash `set -e` is ignored when a return value is inverted with `!`, so such an
assertion is **inert**: it reads like a check and checks nothing. One of the two
guards was already false on a clean tree (the comment explaining the removal
names the old literal, and a whole-block grep found the explanation), and the
mutation run still went green because a different assertion further down did the
work. Every assertion is now either plain or final, and the guards read the
executable lines only.

## Local verification

- `bash -n` and `shellcheck -S warning` clean on all six scripts.
- `check-docs-consistency.sh` and `update-facts-block.sh --check` both exit 0.
- Full `bats tests/`: 1437 pass, 10 fail - **all ten reproduce identically on a
  clean `origin/main` worktree** and are environment-related (Git Bash on
  Windows: file mode 600, control-character escaping). No new failures.
- `preflight-check.sh` reports the signature step as failed. That is structural,
  not a regression: it verifies the working tree against the **previous** tag's
  signatures, so it cannot pass on any branch that edits the six scripts. The
  two untouched installers verify fine.
