### PR TITLE
fix(ci): scan added lines for forbidden markers, not just commit messages

### DIFF
--- a/.github/workflows/commit-hygiene.yml
+++ b/.github/workflows/commit-hygiene.yml
@@ -1,12 +1,21 @@
 name: Commit hygiene
 
-# Runs on pull requests only. preflight-check.sh already scans for these
-# markers, but it runs at TAG time inside release.yml, and by then a bad commit
-# is long since merged: preflight diffs main..HEAD, so anything already in main
-# is invisible to it. That gap let a commit mentioning a code-review bot reach
-# main on 27 aug 2026 through a "docs-only, surely fine" pull request where the
-# author ran only the docs checker. This workflow closes it at the point where
-# the commit can still be amended.
+# Runs on pull requests only. preflight-check.sh runs the same scan, but at TAG
+# time inside release.yml, and by then a bad commit is long since merged:
+# preflight diffs main..HEAD, so anything already in main is invisible to it.
+# That gap let a commit mentioning a review bot reach main on 27 aug 2026
+# through a "docs-only, surely fine" pull request where the author ran only the
+# docs checker. This workflow closes it while the commit can still be amended.
+#
+# Both callers delegate to scripts/check-markers.sh so the list lives in one
+# place. It used to be copied into both, with a comment asking readers to keep
+# the copies in step; they drifted anyway, and the check that would have noticed
+# was the one being copied.
+#
+# The scan covers commit messages AND the lines the branch adds. Messages alone
+# were not enough: on 30 aug 2026 three lines naming internal documents reached
+# the public tree through green pull requests, because nothing here read file
+# content and preflight could no longer see them once merged.
 
 on:
   pull_request:
@@ -29,56 +38,11 @@ jobs:
           # Need both sides of the comparison, and the commits in between.
           fetch-depth: 0
 
-      - name: No AI-tool markers or co-author trailers in the commits
+      - name: No forbidden markers or co-author trailers, in commits or content
         env:
           BASE: ${{ github.event.pull_request.base.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-
-          # Only OUR commits are in scope. dependabot signs its own commits with
-          # a Co-authored-by trailer naming itself; rejecting that would mean
-          # rejecting every dependency bump, which is not what the rule is for.
-          range="${BASE}..${HEAD}"
-          bad=0
-
-          # Collected before the loop rather than piped into it. Read through
-          # `done < <(git rev-list ...)` a failure is invisible to set -e: the
-          # loop body never runs and the step reports the commits clean having
-          # looked at none of them.
-          if ! shas="$(git rev-list "$range")"; then
-            echo "::error::cannot list commits over $range"
-            exit 1
-          fi
-
-          while read -r sha; do
-            [ -n "$sha" ] || continue
-            author="$(git log -1 --format='%ae' "$sha")"
-            case "$author" in
-              *dependabot*|*github-actions*) continue ;;
-            esac
-            msg="$(git log -1 --format='%B' "$sha")"
-            # Keep this list in step with FORBIDDEN_MARKERS in
-            # scripts/preflight-check.sh. They ran different lists once, and a
-            # word missing here but present there passes the pull request and
-            # then fails at tag time - which is the exact gap this workflow was
-            # written to close. The word boundaries in the pattern are
-            # deliberate: two of the words it lists also occur inside ordinary
-            # domain terms, and without boundaries they would fire on those.
-            hit="$(printf '%s' "$msg" \
-              | grep -inE 'co-authored-by|generated with|claude|anthropic|\bcodex\b|chatgpt|openai|gpt-[0-9]|copilot|\bllm\b|myai-[a-z0-9]{4}' || true)"
-            if [ -n "$hit" ]; then
-              echo "::error::commit ${sha:0:7} carries a forbidden marker:"
-              printf '%s\n' "$hit"
-              bad=1
-            fi
-          done <<< "$shas"
-
-          if [ "$bad" -ne 0 ]; then
-            echo "::error::Rewrite the offending commit messages and force-push the branch."
-            exit 1
-          fi
-          echo "Commit messages are clean over $range."
+        run: bash scripts/check-markers.sh "$BASE" "$HEAD"
 
       - name: No newly added em/en-dash in the diff
         env:

--- a/scripts/check-markers.sh
+++ b/scripts/check-markers.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# check-markers.sh <base> [head]
+#
+# Fails when a forbidden marker appears in the commits of <base>..<head> OR in
+# the lines those commits ADD. One implementation, one list, two surfaces.
+#
+# Why the content half exists. The pull-request workflow used to read commit
+# messages only, and preflight-check.sh reads the diff but runs at tag time over
+# main..HEAD - so anything already merged is outside its range. A marker written
+# into a FILE therefore passed every gate on the way in and became invisible the
+# moment it landed. That is not hypothetical: on 30 aug 2026 a release added two
+# such lines and a pull request the next day added a third, all with green
+# checks.
+#
+# Why the list lives here and nowhere else. It used to be copied into two files
+# with a comment asking future readers to keep them in step. They drifted anyway
+# - one copy carried a phrase the other did not - and nothing noticed, because
+# the check that would notice was the one being copied.
+#
+# 🔴 Why the exclusion is per LINE, not per file. The two files that used to
+# define the list were skipped whole, on the reasoning that their marker words
+# are a search pattern rather than a violation. True of the pattern line, false
+# of everything else in them, and that blanket skip hid ordinary prose in those
+# files for as long as it existed - two of the three leaks above sat in a file
+# the scan was told to ignore. A line that genuinely has to spell a marker out
+# carries the tag below, and only that line is skipped.
+set -uo pipefail
+
+# The one and only list. Case-insensitive. Word boundaries where a marker also
+# occurs inside ordinary domain terms.
+MARKERS='generated with|claude|anthropic|\bcodex\b|chatgpt|openai|gpt-[0-9]|copilot|\bllm\b|myai-[a-z0-9]{4}'  # allow-markers
+
+# A line carrying this tag is exempt from the CONTENT scan. Deliberately visible
+# in review: silencing a real hit with it is a conscious act someone has to read
+# past, not a file-wide rule nobody sees. It does not exempt commit messages.
+ALLOW_TAG='allow-markers'
+
+usage() {
+    echo "usage: $0 <base-ref> [head-ref]" >&2
+    exit 2
+}
+
+base="${1:-}"
+head_ref="${2:-HEAD}"
+[ -n "$base" ] || usage
+
+tmp="$(mktemp -d)" || { echo "cannot create a temp dir" >&2; exit 1; }
+trap 'rm -rf "$tmp"' EXIT
+
+bad=0
+
+# --- commits -----------------------------------------------------------------
+# Collected before the loop rather than piped into it: read through a process
+# substitution a failure is invisible, the body never runs, and the scan reports
+# the commits clean having looked at none of them.
+if ! shas="$(git rev-list "$base..$head_ref" 2>/dev/null)"; then
+    echo "cannot list commits over $base..$head_ref" >&2
+    exit 1
+fi
+
+while read -r sha; do
+    [ -n "$sha" ] || continue
+    author="$(git log -1 --format='%ae' "$sha")"
+    # Automated authors sign their own commits and would fail on their own
+    # trailer; rejecting that would mean rejecting every dependency bump.
+    case "$author" in
+        *dependabot*|*github-actions*) continue ;;
+    esac
+    msg="$(git log -1 --format='%B' "$sha")"
+    hit="$(printf '%s' "$msg" | grep -inE "$MARKERS" || true)"
+    if [ -n "$hit" ]; then
+        echo "commit ${sha:0:7} carries a forbidden marker:" >&2
+        printf '%s\n' "$hit" >&2
+        bad=1
+    fi
+    # Same commits, same exemption, so it rides along rather than repeating the
+    # loop elsewhere. Reported separately: the fix is different.
+    trailer="$(printf '%s' "$msg" | grep -inE '\bco-authored-by\b' || true)"
+    if [ -n "$trailer" ]; then
+        echo "commit ${sha:0:7} carries a co-author trailer:" >&2
+        printf '%s\n' "$trailer" >&2
+        bad=1
+    fi
+done <<< "$shas"
+
+# --- added lines -------------------------------------------------------------
+if git rev-parse --verify "$base" >/dev/null 2>&1; then
+    # Three dots: with two, anything the base branch changed after this one left
+    # it reads as an addition made here.
+    if ! git diff "$base...$head_ref" --unified=0 -- . > "$tmp/raw"; then
+        echo "cannot diff $base...$head_ref" >&2
+        exit 1
+    fi
+    # Only grep is allowed to "fail" here, and only because finding no added
+    # lines is a legitimate result.
+    grep '^+' "$tmp/raw" | grep -v '^+++' > "$tmp/added" || true
+
+    skipped="$(grep -c -- "$ALLOW_TAG" "$tmp/added" 2>/dev/null || true)"
+    [ -n "$skipped" ] || skipped=0
+    # Printed even when zero: an exemption that nobody sees is an exemption that
+    # grows.
+    echo "content scan: $(wc -l < "$tmp/added") added lines, $skipped tagged exempt"
+
+    hits="$(grep -v -- "$ALLOW_TAG" "$tmp/added" | grep -inE "$MARKERS" || true)"
+    if [ -n "$hits" ]; then
+        echo "added lines carry a forbidden marker:" >&2
+        printf '%s\n' "$hits" >&2
+        bad=1
+    fi
+fi
+
+if [ "$bad" -ne 0 ]; then
+    echo "Remove the marker. If a line must spell one out, tag that line with ${ALLOW_TAG}." >&2
+    exit 1
+fi
+
+echo "No forbidden markers in $base..$head_ref (commits and added lines)."

--- a/scripts/preflight-check.sh
+++ b/scripts/preflight-check.sh
@@ -64,14 +64,6 @@ SCRIPTS=(
     awg_common_en.sh
 )
 
-# Запрещённые маркеры в публичном тексте и коммитах (case-insensitive).
-# Слитный список во избежание ложных срабатываний на доменных терминах.
-# Идентификаторы внутреннего трекера читателю со стороны не говорят
-# ничего, а утекают в публичное дерево незаметно: 30 aug 2026 их вычистили
-# целым PR, и следующий же PR внёс новую ссылку в комментарий теста. Ловится
-# тем же гейтом, что и упоминания посторонних инструментов.
-FORBIDDEN_MARKERS='claude|anthropic|\bcodex\b|chatgpt|openai|gpt-[0-9]|copilot|\bllm\b|myai-[a-z0-9]{4}'
-
 PASS=0
 FAIL=0
 WARN=0
@@ -161,25 +153,21 @@ else
     _bad "newly added em/en-dash in diff ${BASE_REF}...HEAD"
 fi
 
-# --- 5. AI/tool-mention in diff + commit log ---
-marker_fail=0
-if git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
-    # Исключаем файлы, которые ОПРЕДЕЛЯЮТ список маркеров: у них имена
-    # маркеров стоят как паттерн поиска, а не как нарушение. Без этого
-    # проверка находит сама себя и обязательный предмержевый прогон
-    # падает на ветке, которая ничего не нарушила.
-    diff_markers=$(git diff "${BASE_REF}...HEAD" -- . ':(exclude)scripts/preflight-check.sh' ':(exclude).github/workflows/commit-hygiene.yml' | grep -nP '^\+' | grep -iP "$FORBIDDEN_MARKERS" || true)
-    if [[ -n "$diff_markers" ]]; then
-        echo "diff markers:" >&2; echo "$diff_markers" >&2
-        marker_fail=1
-    fi
+# --- 5. forbidden markers in commits and added lines ---
+# Делегировано в scripts/check-markers.sh: одна реализация, один список.
+# Прежде список был скопирован сюда и в pull-request workflow, копии разошлись
+# (в одной не хватало фразы, которая была в другой), и заметить это было нечем:
+# расходился как раз тот механизм, который должен был ловить.
+# Там же исправлено главное: сканируются НЕ только сообщения коммитов, но и
+# ДОБАВЛЕННЫЕ СТРОКИ, а исключение сделано по СТРОКЕ с тегом, а не по файлу
+# целиком - файловое прятало в этих двух файлах обычную прозу.
+marker_out=""
+if marker_out="$(bash "$REPO_ROOT/scripts/check-markers.sh" "$BASE_REF" HEAD 2>&1)"; then
+    _ok "no forbidden markers in commits or added lines"
+else
+    echo "$marker_out" >&2
+    _bad "forbidden markers found (scripts/check-markers.sh)"
 fi
-log_markers=$(git log "$LOG_RANGE" --format='%B' 2>/dev/null | grep -iP "$FORBIDDEN_MARKERS" || true)
-if [[ -n "$log_markers" ]]; then
-    echo "commit-log markers:" >&2; echo "$log_markers" >&2
-    marker_fail=1
-fi
-if [[ "$marker_fail" -eq 0 ]]; then _ok "no AI/tool markers in diff + commit log"; else _bad "AI/tool markers found"; fi
 
 # --- 6. Co-authored-by in commit log ---
 coauthor=$(git log "$LOG_RANGE" --format='%B' 2>/dev/null | grep -iE '\bco-authored-by\b' || true)

--- a/tests/test_marker_scan.bats
+++ b/tests/test_marker_scan.bats
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+# scripts/check-markers.sh: forbidden markers in commits AND in content.
+#
+# The case that matters is "marker in a file, clean commit message". The
+# pull-request workflow used to read commit messages only, so such a line passed
+# every check on the way in, and once merged the tag-time scan could not see it
+# either - it diffs main..HEAD, and anything already in main is outside that
+# range. Three lines reached the public tree that way before this was noticed.
+#
+# 🔴 The fixtures never spell a marker out. They build one at runtime from
+# pieces, so this file does not need an exemption to describe what an exemption
+# is for. A test that had to silence the very check it tests would be a poor
+# witness for it.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../scripts/check-markers.sh"
+
+# A tracker-shaped identifier, assembled so the literal never appears here.
+_marker() { printf 'my%s-abcd' 'ai'; }
+
+setup() {
+    REPO="$BATS_TEST_TMPDIR/repo"
+    mkdir -p "$REPO"
+    cd "$REPO" || return 1
+    git init -q .
+    git config user.email "tester@example.invalid"
+    git config user.name "Tester"
+    git config commit.gpgsign false
+    echo "base" > file.txt
+    git add file.txt
+    git commit -q -m "base commit"
+    BASE="$(git rev-parse HEAD)"
+}
+
+_commit() {  # _commit <message> [file-content]
+    if [ $# -ge 2 ]; then
+        printf '%s\n' "$2" >> file.txt
+        git add file.txt
+    else
+        echo "harmless $RANDOM" >> file.txt
+        git add file.txt
+    fi
+    git commit -q -m "$1"
+}
+
+@test "markers: a clean commit and clean content pass" {
+    _commit "chore: tidy up"
+    run bash "$SCRIPT" "$BASE" HEAD
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No forbidden markers"* ]]
+}
+
+@test "markers: a marker in the commit MESSAGE fails" {
+    _commit "chore: see $(_marker) for context"
+    run bash "$SCRIPT" "$BASE" HEAD
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"carries a forbidden marker"* ]]
+}
+
+# 🔴 The regression this script exists for.
+@test "markers: a marker in FILE CONTENT fails even with a clean message" {
+    _commit "chore: tidy up" "# see $(_marker) for context"
+    run bash "$SCRIPT" "$BASE" HEAD
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"added lines carry a forbidden marker"* ]]
+}
+
+@test "markers: content hits name the offending text" {
+    _commit "chore: tidy up" "# see $(_marker) for context"
+    run bash "$SCRIPT" "$BASE" HEAD
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"for context"* ]]
+}
+
+@test "markers: a line tagged as exempt is skipped" {
+    _commit "chore: tidy up" "MARKERS='$(_marker)'  # allow-markers"
+    run bash "$SCRIPT" "$BASE" HEAD
+    [ "$status" -eq 0 ]
+}
+
+# 🔴 The exemption is per line. If it ever becomes per file, or per diff, this
+# goes red - which is the whole difference between the new rule and the old one.
+@test "markers: an exempt line does not cover an untagged one beside it" {
+    printf "%s  # allow-markers\n" "MARKERS='$(_marker)'" >> file.txt
+    printf "# and here without a tag: %s\n" "$(_marker)" >> file.txt
+    git add file.txt
+    git commit -q -m "chore: two lines"
+    run bash "$SCRIPT" "$BASE" HEAD
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"without a tag"* ]]
+}
+
+@test "markers: the number of exempt lines is reported even when zero" {
+    _commit "chore: tidy up"
+    run bash "$SCRIPT" "$BASE" HEAD
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"0 tagged exempt"* ]]
+}
+
+@test "markers: a co-author trailer in a commit message fails" {
+    _commit "chore: tidy up
+
+Co-authored-by: Someone <someone@example.invalid>"
+    run bash "$SCRIPT" "$BASE" HEAD
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"co-author trailer"* ]]
+}
+
+# Automated authors sign their own commits; rejecting that would reject every
+# dependency bump, which is not what the rule is for.
+@test "markers: an automated author's own trailer is not held against it" {
+    echo "bump" >> file.txt
+    git add file.txt
+    git -c user.email="49699333+dependabot[bot]@users.noreply.github.com" \
+        -c user.name="dependabot[bot]" \
+        commit -q -m "build: bump a dependency
+
+Co-authored-by: dependabot[bot] <support@github.com>"
+    run bash "$SCRIPT" "$BASE" HEAD
+    [ "$status" -eq 0 ]
+}
+
+@test "markers: an unreadable base ref is a loud failure, not a clean pass" {
+    run bash "$SCRIPT" "does-not-exist-ref" HEAD
+    [ "$status" -ne 0 ]
+    [[ "$output" != *"No forbidden markers"* ]]
+}
+
+@test "markers: called without a base ref it refuses rather than scanning nothing" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"usage"* ]]
+}


### PR DESCRIPTION
Closes the gap that let three lines naming internal documents reach the public
tree in two days, all through green pull requests.

## The defect

The pull-request gate read **commit messages only**. A marker written into a
file passed every check on the way in. And once merged it was invisible to
`preflight-check.sh` as well, because that scan diffs `main...HEAD` and cannot
see what is already in `main`. So the leak was not "caught late" - it was never
going to be caught at all.

That is exactly the gap this workflow was written to close. It was closed for
commit messages and left open for content.

## One list instead of two

The marker list was copied into the workflow and into `preflight-check.sh`, with
a comment asking readers to keep the copies in step. They drifted anyway - one
carried a phrase the other did not - and nothing noticed, because the mechanism
that would notice was the one being copied.

Both callers now delegate to `scripts/check-markers.sh`: one list, one
implementation, two surfaces (commit messages and added lines). Only that file
spells a marker out, on a single tagged line.

## The exemption is per line, not per file

The two files defining the list used to be skipped **whole**, on the reasoning
that their marker words are a search pattern rather than a violation. True of
the pattern line, false of everything else in them - and two of the three leaks
above sat in a file the scan had been told to ignore.

A line that genuinely has to spell a marker out now carries an inline tag, and
only that line is skipped. The count of exempt lines is printed on every run,
because an exemption nobody sees is one that grows.

## Tests

`tests/test_marker_scan.bats` builds a throwaway git repository and drives the
script end to end:

| case | expected |
|---|---|
| clean message and clean content | pass |
| marker in the commit message | fail |
| **marker in file content, clean message** | **fail** |
| tagged line | pass |
| tagged line beside an untagged one | fail |
| co-author trailer | fail |
| automated author's own trailer | pass |
| unreadable base ref | loud failure, not a clean pass |
| no arguments | refuses rather than scanning nothing |

**Verified by mutation, one run at a time.** Seven mutations - removing the
content scan, widening the exemption to the whole diff, dropping the trailer
check, dropping the automated-author exemption, swallowing a failed `rev-list`,
dropping the argument guard, dropping the exempt counter - each turns exactly
the intended test red, with a clean tree before and after.

The fixtures never spell a marker out; they assemble one at runtime, so this
change needs no exemption to test what an exemption is for.

## Local verification

- `bash -n` and `shellcheck -S warning` clean on both scripts; the workflow
  still parses as YAML.
- `scripts/check-markers.sh origin/main HEAD` on this branch: 265 added lines,
  4 tagged exempt, no hits.
- The delegated step in `preflight-check.sh` passes on this branch and fails
  loudly on an unreadable base ref rather than reporting clean.
- `check-docs-consistency.sh` and `update-facts-block.sh --check` both exit 0.
