### PR TITLE
Fix adding ::/0 when IPv6 is disabled

### DIFF
--- a/awg_common.sh
+++ b/awg_common.sh
@@ -370,7 +370,7 @@ _append_ipv6_full_tunnel_route() {
     # пробел склеил бы два маршрута в один нечитаемый токен.
     list="${list//$'\r'/}"
     list="${list//$'\n'/, }"
-    if [[ "$list" != *:* ]] && _is_full_tunnel "$list"; then
+    if [[ "${DISABLE_IPV6:-0}" != "1" && "$list" != *:* ]] && _is_full_tunnel "$list"; then
         printf '%s, ::/0' "$list"
     else
         printf '%s' "$list"

--- a/tests/test_add_allowed_ips.bats
+++ b/tests/test_add_allowed_ips.bats
@@ -202,6 +202,16 @@ _client_allowed_ips() {
     unset CLIENT_ALLOWED_IPS
 }
 
+@test "render: full-tunnel v4 override does not get ::/0 when IPv6 is disabled" {
+    setup_params
+    export DISABLE_IPV6=1
+    export CLIENT_ALLOWED_IPS="0.0.0.0/0"
+    run render_client_config "fullv4_no_v6" "10.9.9.5" "CLIENT_PRIV" "SERVER_PUB" "1.2.3.4" "39743"
+    [ "$status" -eq 0 ]
+    [ "$(_client_allowed_ips fullv4_no_v6)" = "0.0.0.0/0" ]
+    unset CLIENT_ALLOWED_IPS DISABLE_IPV6
+}
+
 @test "render: override that already carries ::/0 is written as-is" {
     setup_params
     export CLIENT_ALLOWED_IPS="0.0.0.0/0, ::/0"


### PR DESCRIPTION
Fixes #259
## Summary

При `DISABLE_IPV6=1` генератор клиентской конфигурации добавлял `::/0` в `AllowedIPs`.

Изменена проверка в `_append_ipv6_full_tunnel_route()`, чтобы IPv6 default route добавлялся только при включённом IPv6.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] CI/CD
- [ ] Refactoring

## Checklist

- [x] `bash -n` passes for all modified scripts
- [ ] `shellcheck -s bash -S warning` passes
- [ ] `bats tests/` passes (add a test for new behaviour)
- [ ] `scripts/check-docs-consistency.sh` passes (if docs or metadata changed)
- [ ] Tested on clean Ubuntu 24.04 LTS VPS (if script changes)
- [ ] Tested on Ubuntu 25.10/26.04 (noble fallback path, if PPA/install logic changes)
- [ ] Tested on Debian 12/13 (if OS-specific changes)
- [ ] CHANGELOG.md **and** CHANGELOG.en.md updated (including `[Unreleased]` comparator link), or not applicable (internal/test-only change)
- [ ] SCRIPT_VERSION updated (if releasing new version)
- [ ] SHA pins recomputed and verified (`scripts/update-sha-pins.sh --verify`) (if `awg_common*`/`manage_amneziawg*` changed)
- [ ] Version badge in README.md and README.en.md updated (if version bump)
- [ ] Documentation updated (if applicable)
- [x] Security-sensitive changes reviewed (no eval/source on user data, strict permissions)
- [ ] English script versions (`_en.sh`) synchronized (if Russian scripts modified)
- [ ] Rollback tested: `--uninstall` + fresh install (if installer changes)
- [ ] vpn:// URI generation verified (if `awg_common` changes)